### PR TITLE
Adds inscribed polygons SDF.

### DIFF
--- a/playgrounds/terrain/src/sdf.rs
+++ b/playgrounds/terrain/src/sdf.rs
@@ -3,11 +3,11 @@ pub mod inscribed_polygon;
 pub mod perlin_terrain;
 
 pub use combinators::{
-	Difference, Elongate, Intersection, RotateY, Round, Scale, SmoothDifference,
+	AddY, Difference, Elongate, Intersection, RotateY, Round, Scale, SmoothDifference,
 	SmoothIntersection, SmoothUnion, Translate, Union,
 };
 pub use inscribed_polygon::InscribedPolygonSdf;
-pub use perlin_terrain::PerlinTerrainSdf;
+pub use perlin_terrain::{ElevationModulation, PerlinTerrainSdf};
 
 use bevy::prelude::*;
 

--- a/playgrounds/terrain/src/sdf/combinators.rs
+++ b/playgrounds/terrain/src/sdf/combinators.rs
@@ -1,6 +1,33 @@
 use crate::sdf::Sdf;
 use bevy::prelude::*;
 
+/// Add two SDFs together - adds their heights (for heightfield-like SDFs)
+/// This is useful for adding features to terrain (bumps, depressions, etc.)
+/// The result is the sum of the two surfaces
+pub struct AddY<A, B> {
+	a: A,
+	b: B,
+}
+
+impl<A: Sdf, B: Sdf> AddY<A, B> {
+	pub fn new(a: A, b: B) -> Self {
+		Self { a, b }
+	}
+}
+
+impl<A: Sdf, B: Sdf> Sdf for AddY<A, B> {
+	fn distance(&self, p: Vec3) -> f32 {
+		// For heightfield-like SDFs where distance = p.y - height(x,z):
+		// If d1 = p.y - h1 and d2 = p.y - h2
+		// And we want h_combined = h1 + h2
+		// Then d_combined = p.y - (h1 + h2) = (p.y - h1) + (p.y - h2) - p.y
+		// = d1 + d2 - p.y
+		let da = self.a.distance(p);
+		let db = self.b.distance(p);
+		da + db - p.y
+	}
+}
+
 /// Union of two SDFs - combines them using the minimum distance
 /// This creates the union of the two shapes
 pub struct Union<A, B> {

--- a/playgrounds/terrain/src/sdf/inscribed_polygon.rs
+++ b/playgrounds/terrain/src/sdf/inscribed_polygon.rs
@@ -1,4 +1,4 @@
-use crate::sdf::Sdf;
+use crate::sdf::{perlin_terrain::ElevationModulation, Sdf};
 use bevy::prelude::*;
 
 /// SDF for an inscribed polygon feature
@@ -154,6 +154,15 @@ impl Sdf for InscribedPolygonSdf {
 
 		// Return signed distance: negative if below surface, positive if above
 		p.y - surface_y
+	}
+}
+
+impl ElevationModulation for InscribedPolygonSdf {
+	/// Returns the height offset at a given (x, z) position
+	/// This allows the inscribed polygon to be used as a 2.5D elevation modulation
+	fn height_offset(&self, x: f32, z: f32) -> f32 {
+		let p_2d = Vec2::new(x, z);
+		self.get_height_at(p_2d)
 	}
 }
 

--- a/playgrounds/terrain/src/sdf/perlin_terrain.rs
+++ b/playgrounds/terrain/src/sdf/perlin_terrain.rs
@@ -3,16 +3,27 @@ use crate::terrain::TerrainConfig;
 use bevy::prelude::*;
 use noise::{NoiseFn, Perlin};
 
+/// Trait for elevation modulations that modify terrain height in 2.5D
+/// Returns the height offset at a given (x, z) position (Y is ignored)
+pub trait ElevationModulation: Send + Sync {
+	fn height_offset(&self, x: f32, z: f32) -> f32;
+}
+
 /// SDF representation of Perlin noise-based terrain
 /// Converts the heightfield `y = height(x, z)` into an SDF: `f(p) = p.y - height(p.x, p.z)`
 pub struct PerlinTerrainSdf {
 	perlin: Perlin,
 	config: TerrainConfig,
+	elevation_modulations: Vec<Box<dyn ElevationModulation>>,
 }
 
 impl PerlinTerrainSdf {
 	pub fn new(seed: u32, config: TerrainConfig) -> Self {
-		Self { perlin: Perlin::new(seed), config }
+		Self { perlin: Perlin::new(seed), config, elevation_modulations: Vec::new() }
+	}
+
+	pub fn add_elevation_modulation(&mut self, modulation: Box<dyn ElevationModulation>) {
+		self.elevation_modulations.push(modulation);
 	}
 
 	/// Calculate the terrain height at a given (x, z) position
@@ -33,15 +44,10 @@ impl PerlinTerrainSdf {
 			frequency *= 2.0;
 		}
 
-		let exponent = 1.2; // >1 exaggerates contrast, <1 flattens
+		let exponent = 1.1; // >1 exaggerates contrast, <1 flattens
 		let sign = height.signum();
 		let height = sign * height.abs().powf(exponent);
 		let height = height * self.config.height_scale;
-
-		// Apply geographic features (canyons, etc.)
-		/*if let Some(registry) = &self.feature_registry {
-			height = registry.apply_features(world_x, world_z, height, &self.config);
-		}*/
 
 		height
 	}
@@ -50,10 +56,15 @@ impl PerlinTerrainSdf {
 impl Sdf for PerlinTerrainSdf {
 	fn distance(&self, p: Vec3) -> f32 {
 		// Compute surface height from noise
-		let terrain_height = self.height_at(p.x, p.z);
+		let mut terrain_height = self.height_at(p.x, p.z);
+
+		// Apply elevation modulations (2.5D height offsets)
+		for modulation in &self.elevation_modulations {
+			terrain_height += modulation.height_offset(p.x, p.z);
+		}
 
 		// Define bedrock level (bottom of world)
-		let bedrock_level = -self.config.height_scale * 2.0;
+		let bedrock_level = -self.config.height_scale * 4.0;
 
 		// Distance to surface
 		let d_surface = p.y - terrain_height;


### PR DESCRIPTION
# Summary
Adds inscribed polygons SDF. This is particularly useful for height-map like terrain models. You can compose inscribe polygons with height-map terrain models to force high- and low-lying regions via `AddY` as a generic SDF operation or `add_terrain_modulation`. The latter prevents mutating the terrain bedrock facet. 