### PR TITLE
Adds grading and rounding terrain manipulations.

### DIFF
--- a/playgrounds/terrain/src/chunk.rs
+++ b/playgrounds/terrain/src/chunk.rs
@@ -133,10 +133,11 @@ pub struct ChunkConfig {
 impl Default for ChunkConfig {
 	fn default() -> Self {
 		Self {
+			// 10 km (100 x 100 meters)
 			chunk_size: 100.0,
-			load_radius: 3,
-			max_render_distance: 5,
-			world_size_chunks: 32, // 32x32 chunks = 3200x3200 world units, wraps around
+			load_radius: 8, // load out to 100 km
+			max_render_distance: 8, // render out to 100 km
+			world_size_chunks: 512, // 512x512 chunks = 25600x25600 world units, wraps around, 2560 km
 		}
 	}
 }

--- a/playgrounds/terrain/src/sdf/region.rs
+++ b/playgrounds/terrain/src/sdf/region.rs
@@ -1,5 +1,7 @@
 pub mod affine;
 pub mod branching;
+pub mod rounding;
+pub mod grading;
 
 use bevy::prelude::*;
 use noise::{NoiseFn, Perlin};
@@ -74,6 +76,7 @@ impl RegionNoise {
 		let value = self.sample_fbm(x, z, amplitude, frequency);
 		value.signum() * (amplitude - value.abs())
 	}
+
 }
 
 impl Region2D {
@@ -99,6 +102,11 @@ impl Region2D {
 	#[inline(always)]
 	pub fn sdf(&self, p: Vec2) -> f32 {
 		self.sdf_with_noise(p, None)
+	}
+
+	/// Checks if the point is inside the region.
+	pub fn is_inside(&self, p: Vec2) -> bool {
+		self.sdf(p) < 0.0
 	}
 
 	/// Signed distance with optional noise perturbation

--- a/playgrounds/terrain/src/sdf/region/affine.rs
+++ b/playgrounds/terrain/src/sdf/region/affine.rs
@@ -1,4 +1,4 @@
-use crate::sdf::perlin_terrain::ElevationModulation;
+use crate::sdf::perlin_terrain::{ElevationModulation, PerlinTerrainSdf};
 use crate::sdf::region::{Region2D, RegionNoise};
 use bevy::prelude::*;
 
@@ -103,7 +103,7 @@ impl RegionAffineModulation {
 }
 
 impl ElevationModulation for RegionAffineModulation {
-	fn modify_elevation(&self, elevation: f32, x: f32, z: f32) -> f32 {
+	fn modify_elevation(&self, _perlin_terrain: &PerlinTerrainSdf, elevation: f32, x: f32, z: f32, _index: usize) -> f32 {
 		let p = Vec2::new(x, z);
 		let w = self.region_weight(p);
 

--- a/playgrounds/terrain/src/sdf/region/branching.rs
+++ b/playgrounds/terrain/src/sdf/region/branching.rs
@@ -39,7 +39,6 @@ impl BranchingPlan {
 						let mut noise = noise.unwrap_or(fallback_noise.clone());
 						noise.noise = noise.noise.set_seed(noise.noise.seed() + (i * j * k + i + j + k) as u32);
 						let new_region = region.branch_region(&noise);
-						println!{"new_region({},{},{}): {:?}", i, j, k, new_region};
 						new_regions.push(new_region);
 					}
 					new_regions

--- a/playgrounds/terrain/src/sdf/region/grading.rs
+++ b/playgrounds/terrain/src/sdf/region/grading.rs
@@ -1,0 +1,88 @@
+use crate::sdf::perlin_terrain::{ElevationModulation, PerlinTerrainSdf};
+use crate::sdf::region::{Region2D, RegionNoise};
+use bevy::prelude::*;
+
+/// Rounds the terrain height to the nearest unit amount.
+#[derive(Debug, Clone)]
+pub struct RegionGradingModulation {
+	/// The region to round.
+	pub region: Region2D,
+	/// The start point of the grading.
+	pub start: Vec2,
+    /// The elevation at the start point.
+	pub start_elevation: f32,
+    /// The end point
+    pub end: Vec2,
+    /// The elevation at the end point.
+    pub end_elevation: f32,
+    /// Optional noise for perturbing the region boundary
+	pub noise: Option<RegionNoise>,
+	/// The inner radius of the region.
+	pub inner_radius: f32,
+	/// The outer radius of the region.
+	pub outer_radius: f32,
+}
+
+impl RegionGradingModulation {
+	pub fn new(
+		region: Region2D,
+		start: Vec2,
+		start_elevation: f32,
+		end: Vec2,
+		end_elevation: f32,
+        noise: Option<RegionNoise>,
+        inner_radius: f32,
+        outer_radius: f32,
+	) -> Self {
+		Self {
+			region,
+			start,
+			start_elevation,
+			end,
+			end_elevation,
+            noise,
+            inner_radius,
+            outer_radius,
+		}
+	}
+
+	#[inline(always)]
+	fn smoothstep(t: f32) -> f32 {
+		let t = t.clamp(0.0, 1.0);
+		t * t * (3.0 - 2.0 * t)
+	}
+
+	#[inline(always)]
+	fn region_weight(&self, p: Vec2) -> f32 {
+		let d = self.region.sdf_with_noise(p, self.noise.as_ref());
+		if d < -self.inner_radius {
+			0.0
+		} else if d > self.outer_radius {
+			1.0
+		} else {
+			let t = (d + self.inner_radius) / (self.inner_radius + self.outer_radius);
+			Self::smoothstep(t)
+		}
+	}
+
+}
+
+impl ElevationModulation for RegionGradingModulation {
+	fn modify_elevation(&self, _perlin_terrain: &PerlinTerrainSdf, elevation: f32, x: f32, z: f32, _index: usize) -> f32 {
+
+        // compute the distance to the start and end points
+       let distance_to_start = (Vec2::new(x, z) - self.start).length();
+       let distance_to_end = (Vec2::new(x, z) - self.end).length();
+
+       // compute the fraction of the total distance which is the progress from the start
+       let progress = distance_to_start / (distance_to_start + distance_to_end);
+
+       // interpolate the elevation between the start and end points using the progress
+       let interpolated_elevation = self.start_elevation + (self.end_elevation - self.start_elevation) * progress;
+
+	   // weighted elevation and the interpolated elevation
+	   let weight = self.region_weight(Vec2::new(x, z));
+
+       weight * elevation + (1.0 - weight) * interpolated_elevation
+	}
+}

--- a/playgrounds/terrain/src/sdf/region/rounding.rs
+++ b/playgrounds/terrain/src/sdf/region/rounding.rs
@@ -1,0 +1,67 @@
+use crate::sdf::perlin_terrain::{ElevationModulation, PerlinTerrainSdf};
+use crate::sdf::region::{Region2D, RegionNoise};
+use bevy::prelude::*;
+
+/// Rounds the terrain height to the nearest unit amount.
+#[derive(Debug, Clone)]
+pub struct RegionRoundingModulation {
+	/// The region to round.
+	pub region: Region2D,
+	/// The neareast unit amount to round down to. 
+    pub nearest: f32,
+	/// Optional noise for perturbing the region boundary
+	pub noise: Option<RegionNoise>,
+	/// The inner radius of the region.
+	pub inner_radius: f32,
+	/// The outer radius of the region.
+	pub outer_radius: f32,
+}
+
+impl RegionRoundingModulation {
+	pub fn new(
+		region: Region2D,
+		nearest: f32,
+		noise: Option<RegionNoise>,
+		inner_radius: f32,
+		outer_radius: f32,
+	) -> Self {
+		Self {
+			region,
+			nearest,
+			noise,
+			inner_radius,
+			outer_radius,
+		}
+	}
+
+	#[inline(always)]
+	fn smoothstep(t: f32) -> f32 {
+		let t = t.clamp(0.0, 1.0);
+		t * t * (3.0 - 2.0 * t)
+	}
+
+	#[inline(always)]
+	fn region_weight(&self, p: Vec2) -> f32 {
+		let d = self.region.sdf_with_noise(p, self.noise.as_ref());
+		if d < -self.inner_radius {
+			0.0
+		} else if d > self.outer_radius {
+			1.0
+		} else {
+			let t = (d + self.inner_radius) / (self.inner_radius + self.outer_radius);
+			Self::smoothstep(t)
+		}
+	}
+
+}
+
+impl ElevationModulation for RegionRoundingModulation {
+	fn modify_elevation(&self, _perlin_terrain: &PerlinTerrainSdf, elevation: f32, x: f32, z: f32, _index: usize) -> f32 {
+       let rounded = (elevation / self.nearest).round() * self.nearest;
+
+	   // weighted elevation and the rounded elevation
+	   let weight = self.region_weight(Vec2::new(x, z));
+
+       weight * elevation + (1.0 - weight) * rounded
+	}
+}


### PR DESCRIPTION
# Summary
Adds grading and rounding terrain manipulations.

> [!NOTE] 
> Current rendering resolutions used for development need larger than intended terrain size to work nicely. 

> [!NOTE]
> Averaging is too costly because of the need to compute modulation layers for yet unsampled points (though this could be memoized), rounding and grading are better. 