### PR TITLE
Fixes the near plane geometry. 

### DIFF
--- a/playgrounds/terrain/src/camera.rs
+++ b/playgrounds/terrain/src/camera.rs
@@ -21,7 +21,11 @@ pub fn setup_camera(mut commands: Commands) {
 	commands.spawn((
 		Camera3d::default(),
 		Transform::from_xyz(camera_pos.x, camera_pos.y, camera_pos.z).looking_at(look_at, Vec3::Y),
-		Projection::Perspective(PerspectiveProjection::default()),
+		Projection::Perspective(PerspectiveProjection {
+			near: 0.0001, // 10 cm
+			far: 2000.0,  // 2000 km
+			..default()
+		}),
 		CameraController {
 			speed: 20.0,
 			sensitivity: 0.005,

--- a/playgrounds/terrain/src/chunk.rs
+++ b/playgrounds/terrain/src/chunk.rs
@@ -172,11 +172,11 @@ pub struct ChunkConfig {
 impl Default for ChunkConfig {
 	fn default() -> Self {
 		Self {
-			min_size: 1.0,      // Cascade begins at 10m resolution
+			min_size: 0.1,      // Cascade begins at 100m resolution
 			number_of_rings: 0, // 4 rings: center + 2 rings = 3^2 = 9 chunks = 900m total
 			world_size: 0.0,    // No wrapping by default
 			grid_radius: 8,     // a radius of 8 chunks
-			grid_multiple_2: 6, // 300 * 64 = 19200m = 19.2km per grid chunk
+			grid_multiple_2: 7, // 300 * 64 = 19200m = 19.2km per grid chunk
 		}
 	}
 }


### PR DESCRIPTION
# Summary
Default Bevy camera settings place near plane to far from view when using km units. 