### PR TITLE
Implements crook cylinder. 

### DIFF
--- a/maybraid/sdf/common-playground/src/commands.rs
+++ b/maybraid/sdf/common-playground/src/commands.rs
@@ -23,6 +23,7 @@ pub const PLAYGROUND_CLI_NAME: &str = "sdf-common";
 /// - `script --path ./setup.txt`
 /// - `render tapered-cylinder --res-2 5`
 /// - `render noisy-cylinder --noise-amplitude 0.08`
+/// - `render crook-cylinder --bend-x 0.15 --bend-z 0.1`
 /// - `settings checker-size --meters 5`
 /// - `settings seed --value 42`
 #[derive(Debug, Clone, Parser, Component)]

--- a/maybraid/sdf/common-playground/src/commands.rs
+++ b/maybraid/sdf/common-playground/src/commands.rs
@@ -24,6 +24,7 @@ pub const PLAYGROUND_CLI_NAME: &str = "sdf-common";
 /// - `render tapered-cylinder --res-2 5`
 /// - `render noisy-cylinder --noise-amplitude 0.08`
 /// - `render crook-cylinder --bend-x 0.15 --bend-z 0.1`
+/// - `render noisy-crook-cylinder --suggested --bend-x 0.12 --bend-z 0.08`
 /// - `settings checker-size --meters 5`
 /// - `settings seed --value 42`
 #[derive(Debug, Clone, Parser, Component)]

--- a/maybraid/sdf/common-playground/src/commands.rs
+++ b/maybraid/sdf/common-playground/src/commands.rs
@@ -25,6 +25,8 @@ pub const PLAYGROUND_CLI_NAME: &str = "sdf-common";
 /// - `render noisy-cylinder --noise-amplitude 0.08`
 /// - `render crook-cylinder --bend-x 0.15 --bend-z 0.1`
 /// - `render noisy-crook-cylinder --suggested --bend-x 0.12 --bend-z 0.08`
+/// - `render ball --radius 0.5`
+/// - `render noisy-ball --suggested`
 /// - `settings checker-size --meters 5`
 /// - `settings seed --value 42`
 #[derive(Debug, Clone, Parser, Component)]

--- a/maybraid/sdf/common-playground/src/commands/README.md
+++ b/maybraid/sdf/common-playground/src/commands/README.md
@@ -6,7 +6,7 @@
 - **Hierarchical `.react(commands)`**: Each command level spawns itself, then spawns children, so deeper types are plain `Component`s for Bevy queries.
 - **Plugins mirror the CLI tree**: A command’s **`plugin.rs`** only composes **child plugins** and registers **systems for that same level** (e.g. announcer). Leaf commands own **`their_dir/plugin.rs`** and optional **`their_dir/plugin/react_*.rs`**.
 - **No `mod.rs`**: Use `feature.rs` + `feature/` for children (Rust 2018 path clarity).
-- **Split types by leaf**: e.g. [`render/tapered_cylinder.rs`](render/tapered_cylinder.rs), [`render/noisy_cylinder.rs`](render/noisy_cylinder.rs) with `TaperedCylinderHelper` / `NoisyCylinderHelper`.
+- **Split types by leaf**: e.g. [`render/tapered_cylinder.rs`](render/tapered_cylinder.rs), [`render/noisy_cylinder.rs`](render/noisy_cylinder.rs), [`render/crook_cylinder.rs`](render/crook_cylinder.rs) with `*Helper` types.
 
 ## React flow
 
@@ -17,7 +17,7 @@
    - `Render` → [`Render::react`](render.rs) spawns [`Render`](render.rs) then the appropriate helper.
    - `Settings` → [`Settings::react`](settings.rs) spawns [`Settings`](settings.rs) then leaf components ([`SettingsCheckerSize`](settings/react_checker_size.rs), [`SettingsSeed`](settings/react_seed.rs)).
 5. **Systems** (registered by plugins, ordered after [`capture_command_line_input`](../input.rs)):
-   - **Render**: [`TaperedCylinderRenderPlugin`](render/tapered_cylinder/plugin.rs), [`NoisyCylinderRenderPlugin`](render/noisy_cylinder/plugin.rs), then [`despawn_render_command_announcer`](render/plugin/announcer.rs) from [`RenderCommandsPlugin`](render/plugin.rs).
+   - **Render**: [`TaperedCylinderRenderPlugin`](render/tapered_cylinder/plugin.rs), [`NoisyCylinderRenderPlugin`](render/noisy_cylinder/plugin.rs), [`CrookCylinderRenderPlugin`](render/crook_cylinder/plugin.rs), then [`despawn_render_command_announcer`](render/plugin/announcer.rs) from [`RenderCommandsPlugin`](render/plugin.rs).
    - **Settings**: checker → seed → announcer via [`SettingsCommandsPlugin`](settings/plugin.rs).
    - [`react_playground_command_root`](root.rs): `help` + despawn root [`PlaygroundCommand`](../commands.rs).
 
@@ -45,6 +45,11 @@ commands/
       plugin.rs
       plugin/
         react_noisy_cylinder.rs
+    crook_cylinder.rs
+    crook_cylinder/
+      plugin.rs
+      plugin/
+        react_crook_cylinder.rs
   settings.rs
   settings/
     plugin.rs

--- a/maybraid/sdf/common-playground/src/commands/render.rs
+++ b/maybraid/sdf/common-playground/src/commands/render.rs
@@ -1,5 +1,6 @@
 pub mod crook_cylinder;
 pub mod noisy_cylinder;
+pub mod noisy_crook_cylinder;
 pub mod plugin;
 pub mod tapered_cylinder;
 mod vec3_args;
@@ -13,6 +14,7 @@ use crate::primitive::PlaygroundPrimitive;
 
 pub use crook_cylinder::CrookCylinderHelper;
 pub use noisy_cylinder::{NoisyCylinderArgs, NoisyCylinderHelper};
+pub use noisy_crook_cylinder::{NoisyCrookCylinderArgs, NoisyCrookCylinderHelper};
 pub use tapered_cylinder::TaperedCylinderHelper;
 
 use vec3_args::parse_vec3_csv;
@@ -62,6 +64,8 @@ pub enum Render {
 	NoisyCylinder(NoisyCylinderHelper),
 	/// Tapered segment with smooth sinusoidal centerline ([RFC-183 3.1.1.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/01-stick-and-stalk-components/02-crook-cylinder/README.md)).
 	CrookCylinder(CrookCylinderHelper),
+	/// Crook cylinder with [`sdf_common::NoiseParams`] surface displacement.
+	NoisyCrookCylinder(NoisyCrookCylinderHelper),
 }
 
 impl Render {
@@ -73,6 +77,7 @@ impl Render {
 			Self::TaperedCylinder(render_helper) => commands.spawn(render_helper),
 			Self::NoisyCylinder(render_helper) => commands.spawn(render_helper),
 			Self::CrookCylinder(render_helper) => commands.spawn(render_helper),
+			Self::NoisyCrookCylinder(render_helper) => commands.spawn(render_helper),
 		};
 	}
 
@@ -99,6 +104,17 @@ impl Render {
 				res_2: h.res_2,
 				transform: h.preview_transform(),
 			},
+			Self::NoisyCrookCylinder(h) => {
+				let crook = h.inner.crook;
+				let noise = h.inner.resolved_noise();
+				PreviewConfig {
+					primitive: PlaygroundPrimitive::NoisyCrookCylinder(NoisySurface::from_params(
+						crook, noise,
+					)),
+					res_2: h.res_2,
+					transform: h.preview_transform(),
+				}
+			}
 		}
 	}
 }

--- a/maybraid/sdf/common-playground/src/commands/render.rs
+++ b/maybraid/sdf/common-playground/src/commands/render.rs
@@ -1,4 +1,6 @@
+pub mod ball;
 pub mod crook_cylinder;
+pub mod noisy_ball;
 pub mod noisy_cylinder;
 pub mod noisy_crook_cylinder;
 pub mod plugin;
@@ -12,7 +14,9 @@ use sdf_common::NoisySurface;
 use crate::preview::PreviewConfig;
 use crate::primitive::PlaygroundPrimitive;
 
+pub use ball::BallHelper;
 pub use crook_cylinder::CrookCylinderHelper;
+pub use noisy_ball::{NoisyBallArgs, NoisyBallHelper};
 pub use noisy_cylinder::{NoisyCylinderArgs, NoisyCylinderHelper};
 pub use noisy_crook_cylinder::{NoisyCrookCylinderArgs, NoisyCrookCylinderHelper};
 pub use tapered_cylinder::TaperedCylinderHelper;
@@ -57,6 +61,7 @@ impl<T: clap::Args> RenderHelper<T> {
 }
 
 #[derive(Debug, Clone, Subcommand, Component)]
+#[command(rename_all = "kebab-case")]
 pub enum Render {
 	/// Smooth tapered cylinder (no procedural surface displacement).
 	TaperedCylinder(TaperedCylinderHelper),
@@ -66,6 +71,10 @@ pub enum Render {
 	CrookCylinder(CrookCylinderHelper),
 	/// Crook cylinder with [`sdf_common::NoiseParams`] surface displacement.
 	NoisyCrookCylinder(NoisyCrookCylinderHelper),
+	/// Solid sphere centered at the origin ([RFC-183 3.1.2.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/02-ball-components/02-noisy-ball/README.md)).
+	Ball(BallHelper),
+	/// Sphere with [`sdf_common::NoiseParams`] surface displacement.
+	NoisyBall(NoisyBallHelper),
 }
 
 impl Render {
@@ -78,6 +87,8 @@ impl Render {
 			Self::NoisyCylinder(render_helper) => commands.spawn(render_helper),
 			Self::CrookCylinder(render_helper) => commands.spawn(render_helper),
 			Self::NoisyCrookCylinder(render_helper) => commands.spawn(render_helper),
+			Self::Ball(render_helper) => commands.spawn(render_helper),
+			Self::NoisyBall(render_helper) => commands.spawn(render_helper),
 		};
 	}
 
@@ -110,6 +121,22 @@ impl Render {
 				PreviewConfig {
 					primitive: PlaygroundPrimitive::NoisyCrookCylinder(NoisySurface::from_params(
 						crook, noise,
+					)),
+					res_2: h.res_2,
+					transform: h.preview_transform(),
+				}
+			}
+			Self::Ball(h) => PreviewConfig {
+				primitive: PlaygroundPrimitive::Ball(h.inner),
+				res_2: h.res_2,
+				transform: h.preview_transform(),
+			},
+			Self::NoisyBall(h) => {
+				let ball = h.inner.ball;
+				let noise = h.inner.resolved_noise();
+				PreviewConfig {
+					primitive: PlaygroundPrimitive::NoisyBall(NoisySurface::from_params(
+						ball, noise,
 					)),
 					res_2: h.res_2,
 					transform: h.preview_transform(),

--- a/maybraid/sdf/common-playground/src/commands/render.rs
+++ b/maybraid/sdf/common-playground/src/commands/render.rs
@@ -1,3 +1,4 @@
+pub mod crook_cylinder;
 pub mod noisy_cylinder;
 pub mod plugin;
 pub mod tapered_cylinder;
@@ -10,6 +11,7 @@ use sdf_common::NoisySurface;
 use crate::preview::PreviewConfig;
 use crate::primitive::PlaygroundPrimitive;
 
+pub use crook_cylinder::CrookCylinderHelper;
 pub use noisy_cylinder::{NoisyCylinderArgs, NoisyCylinderHelper};
 pub use tapered_cylinder::TaperedCylinderHelper;
 
@@ -58,6 +60,8 @@ pub enum Render {
 	TaperedCylinder(TaperedCylinderHelper),
 	/// Tapered cylinder with [`sdf_common::NoiseParams`] surface displacement.
 	NoisyCylinder(NoisyCylinderHelper),
+	/// Tapered segment with smooth sinusoidal centerline ([RFC-183 3.1.1.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/01-stick-and-stalk-components/02-crook-cylinder/README.md)).
+	CrookCylinder(CrookCylinderHelper),
 }
 
 impl Render {
@@ -68,6 +72,7 @@ impl Render {
 		match self {
 			Self::TaperedCylinder(render_helper) => commands.spawn(render_helper),
 			Self::NoisyCylinder(render_helper) => commands.spawn(render_helper),
+			Self::CrookCylinder(render_helper) => commands.spawn(render_helper),
 		};
 	}
 
@@ -89,6 +94,11 @@ impl Render {
 					transform: h.preview_transform(),
 				}
 			}
+			Self::CrookCylinder(h) => PreviewConfig {
+				primitive: PlaygroundPrimitive::CrookCylinder(h.inner),
+				res_2: h.res_2,
+				transform: h.preview_transform(),
+			},
 		}
 	}
 }

--- a/maybraid/sdf/common-playground/src/commands/render/ball.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/ball.rs
@@ -1,0 +1,8 @@
+//! Ball render subcommand (`render ball …`).
+
+pub mod plugin;
+
+use super::RenderHelper;
+use sdf_common::Ball;
+
+pub type BallHelper = RenderHelper<Ball>;

--- a/maybraid/sdf/common-playground/src/commands/render/ball/plugin.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/ball/plugin.rs
@@ -1,0 +1,17 @@
+//! `render ball` plugin and react systems.
+
+mod react_ball;
+
+use bevy::prelude::*;
+
+use crate::input::capture_command_line_input;
+
+pub use react_ball::react_render_helper_ball;
+
+pub struct BallRenderPlugin;
+
+impl Plugin for BallRenderPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(Update, react_render_helper_ball.after(capture_command_line_input));
+	}
+}

--- a/maybraid/sdf/common-playground/src/commands/render/ball/plugin/react_ball.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/ball/plugin/react_ball.rs
@@ -1,0 +1,25 @@
+//! Reacts to [`super::super::BallHelper`].
+
+use bevy::prelude::*;
+
+use crate::commands::render::ball::BallHelper;
+use crate::input::CommandConsoleOutput;
+use crate::preview::PreviewConfig;
+use crate::primitive::PlaygroundPrimitive;
+
+pub fn react_render_helper_ball(
+	mut commands: Commands,
+	q: Query<(Entity, &BallHelper), Added<BallHelper>>,
+	mut preview: ResMut<PreviewConfig>,
+	mut console: ResMut<CommandConsoleOutput>,
+) {
+	for (entity, helper) in &q {
+		*preview = PreviewConfig {
+			primitive: PlaygroundPrimitive::Ball(helper.inner),
+			res_2: helper.res_2,
+			transform: helper.preview_transform(),
+		};
+		console.0.clear();
+		commands.entity(entity).despawn();
+	}
+}

--- a/maybraid/sdf/common-playground/src/commands/render/crook_cylinder.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/crook_cylinder.rs
@@ -1,0 +1,8 @@
+//! Crook-cylinder render subcommand types (`render crook-cylinder …`).
+
+pub mod plugin;
+
+use super::RenderHelper;
+use sdf_common::CrookCylinder;
+
+pub type CrookCylinderHelper = RenderHelper<CrookCylinder>;

--- a/maybraid/sdf/common-playground/src/commands/render/crook_cylinder/plugin.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/crook_cylinder/plugin.rs
@@ -1,0 +1,20 @@
+//! `render crook-cylinder` plugin and react systems.
+
+mod react_crook_cylinder;
+
+use bevy::prelude::*;
+
+use crate::input::capture_command_line_input;
+
+pub use react_crook_cylinder::react_render_helper_crook_cylinder;
+
+pub struct CrookCylinderRenderPlugin;
+
+impl Plugin for CrookCylinderRenderPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(
+			Update,
+			react_render_helper_crook_cylinder.after(capture_command_line_input),
+		);
+	}
+}

--- a/maybraid/sdf/common-playground/src/commands/render/crook_cylinder/plugin/react_crook_cylinder.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/crook_cylinder/plugin/react_crook_cylinder.rs
@@ -1,0 +1,25 @@
+//! Reacts to [`super::super::CrookCylinderHelper`].
+
+use bevy::prelude::*;
+
+use crate::commands::render::crook_cylinder::CrookCylinderHelper;
+use crate::input::CommandConsoleOutput;
+use crate::preview::PreviewConfig;
+use crate::primitive::PlaygroundPrimitive;
+
+pub fn react_render_helper_crook_cylinder(
+	mut commands: Commands,
+	q: Query<(Entity, &CrookCylinderHelper), Added<CrookCylinderHelper>>,
+	mut preview: ResMut<PreviewConfig>,
+	mut console: ResMut<CommandConsoleOutput>,
+) {
+	for (entity, helper) in &q {
+		*preview = PreviewConfig {
+			primitive: PlaygroundPrimitive::CrookCylinder(helper.inner),
+			res_2: helper.res_2,
+			transform: helper.preview_transform(),
+		};
+		console.0.clear();
+		commands.entity(entity).despawn();
+	}
+}

--- a/maybraid/sdf/common-playground/src/commands/render/noisy_ball.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/noisy_ball.rs
@@ -1,0 +1,35 @@
+//! Noisy ball render subcommand (`render noisy-ball …`).
+
+pub mod plugin;
+
+use bevy::prelude::*;
+use clap::Args;
+
+use super::RenderHelper;
+use sdf_common::{Ball, NoiseParams, UnitBallNoiseParams};
+
+/// Inner clap args for noisy ball (sphere + noise flattened).
+#[derive(Debug, Clone, Args, Component)]
+#[command(rename_all = "kebab-case")]
+pub struct NoisyBallArgs {
+	#[command(flatten)]
+	pub ball: Ball,
+	/// Use [`UnitBallNoiseParams`] instead of the flattened noise flags (Perlin, amp 0.05, freq 5, 1 octave).
+	#[arg(long, default_value_t = false)]
+	pub suggested: bool,
+	#[command(flatten)]
+	pub noise: NoiseParams,
+}
+
+impl NoisyBallArgs {
+	/// Noise actually applied after CLI parse (`--suggested` overrides flattened `noise`).
+	pub fn resolved_noise(&self) -> NoiseParams {
+		if self.suggested {
+			UnitBallNoiseParams.into()
+		} else {
+			self.noise
+		}
+	}
+}
+
+pub type NoisyBallHelper = RenderHelper<NoisyBallArgs>;

--- a/maybraid/sdf/common-playground/src/commands/render/noisy_ball/plugin.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/noisy_ball/plugin.rs
@@ -1,0 +1,17 @@
+//! `render noisy-ball` plugin and react systems.
+
+mod react_noisy_ball;
+
+use bevy::prelude::*;
+
+use crate::input::capture_command_line_input;
+
+pub use react_noisy_ball::react_render_helper_noisy_ball;
+
+pub struct NoisyBallRenderPlugin;
+
+impl Plugin for NoisyBallRenderPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(Update, react_render_helper_noisy_ball.after(capture_command_line_input));
+	}
+}

--- a/maybraid/sdf/common-playground/src/commands/render/noisy_ball/plugin/react_noisy_ball.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/noisy_ball/plugin/react_noisy_ball.rs
@@ -1,0 +1,29 @@
+//! Reacts to [`super::super::NoisyBallHelper`].
+
+use bevy::prelude::*;
+
+use sdf_common::NoisySurface;
+
+use crate::commands::render::noisy_ball::NoisyBallHelper;
+use crate::input::CommandConsoleOutput;
+use crate::preview::PreviewConfig;
+use crate::primitive::PlaygroundPrimitive;
+
+pub fn react_render_helper_noisy_ball(
+	mut commands: Commands,
+	q: Query<(Entity, &NoisyBallHelper), Added<NoisyBallHelper>>,
+	mut preview: ResMut<PreviewConfig>,
+	mut console: ResMut<CommandConsoleOutput>,
+) {
+	for (entity, helper) in &q {
+		let ball = helper.inner.ball;
+		let noise = helper.inner.resolved_noise();
+		*preview = PreviewConfig {
+			primitive: PlaygroundPrimitive::NoisyBall(NoisySurface::from_params(ball, noise)),
+			res_2: helper.res_2,
+			transform: helper.preview_transform(),
+		};
+		console.0.clear();
+		commands.entity(entity).despawn();
+	}
+}

--- a/maybraid/sdf/common-playground/src/commands/render/noisy_crook_cylinder.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/noisy_crook_cylinder.rs
@@ -1,0 +1,35 @@
+//! Noisy crook-cylinder render subcommand (`render noisy-crook-cylinder …`).
+
+pub mod plugin;
+
+use bevy::prelude::*;
+use clap::Args;
+
+use super::RenderHelper;
+use sdf_common::{CrookCylinder, NoiseParams, UnitCylinderNoiseParams};
+
+/// Inner clap args for noisy crook (crook + noise flattened).
+#[derive(Debug, Clone, Args, Component)]
+#[command(rename_all = "kebab-case")]
+pub struct NoisyCrookCylinderArgs {
+	#[command(flatten)]
+	pub crook: CrookCylinder,
+	/// Use [`UnitCylinderNoiseParams`] instead of the flattened noise flags (Perlin, amp 0.05, freq 5, 1 octave).
+	#[arg(long, default_value_t = false)]
+	pub suggested: bool,
+	#[command(flatten)]
+	pub noise: NoiseParams,
+}
+
+impl NoisyCrookCylinderArgs {
+	/// Noise actually applied after CLI parse (`--suggested` overrides flattened `noise`).
+	pub fn resolved_noise(&self) -> NoiseParams {
+		if self.suggested {
+			UnitCylinderNoiseParams.into()
+		} else {
+			self.noise
+		}
+	}
+}
+
+pub type NoisyCrookCylinderHelper = RenderHelper<NoisyCrookCylinderArgs>;

--- a/maybraid/sdf/common-playground/src/commands/render/noisy_crook_cylinder/plugin.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/noisy_crook_cylinder/plugin.rs
@@ -1,0 +1,20 @@
+//! `render noisy-crook-cylinder` plugin and react systems.
+
+mod react_noisy_crook_cylinder;
+
+use bevy::prelude::*;
+
+use crate::input::capture_command_line_input;
+
+pub use react_noisy_crook_cylinder::react_render_helper_noisy_crook_cylinder;
+
+pub struct NoisyCrookCylinderRenderPlugin;
+
+impl Plugin for NoisyCrookCylinderRenderPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(
+			Update,
+			react_render_helper_noisy_crook_cylinder.after(capture_command_line_input),
+		);
+	}
+}

--- a/maybraid/sdf/common-playground/src/commands/render/noisy_crook_cylinder/plugin/react_noisy_crook_cylinder.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/noisy_crook_cylinder/plugin/react_noisy_crook_cylinder.rs
@@ -1,0 +1,31 @@
+//! Reacts to [`super::super::NoisyCrookCylinderHelper`].
+
+use bevy::prelude::*;
+
+use sdf_common::NoisySurface;
+
+use crate::commands::render::noisy_crook_cylinder::NoisyCrookCylinderHelper;
+use crate::input::CommandConsoleOutput;
+use crate::preview::PreviewConfig;
+use crate::primitive::PlaygroundPrimitive;
+
+pub fn react_render_helper_noisy_crook_cylinder(
+	mut commands: Commands,
+	q: Query<(Entity, &NoisyCrookCylinderHelper), Added<NoisyCrookCylinderHelper>>,
+	mut preview: ResMut<PreviewConfig>,
+	mut console: ResMut<CommandConsoleOutput>,
+) {
+	for (entity, helper) in &q {
+		let crook = helper.inner.crook;
+		let noise = helper.inner.resolved_noise();
+		*preview = PreviewConfig {
+			primitive: PlaygroundPrimitive::NoisyCrookCylinder(NoisySurface::from_params(
+				crook, noise,
+			)),
+			res_2: helper.res_2,
+			transform: helper.preview_transform(),
+		};
+		console.0.clear();
+		commands.entity(entity).despawn();
+	}
+}

--- a/maybraid/sdf/common-playground/src/commands/render/plugin.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/plugin.rs
@@ -4,6 +4,9 @@ mod announcer;
 
 use bevy::prelude::*;
 
+use super::crook_cylinder::plugin::{
+	react_render_helper_crook_cylinder, CrookCylinderRenderPlugin,
+};
 use super::noisy_cylinder::plugin::{
 	react_render_helper_noisy_cylinder, NoisyCylinderRenderPlugin,
 };
@@ -17,11 +20,17 @@ pub struct RenderCommandsPlugin;
 
 impl Plugin for RenderCommandsPlugin {
 	fn build(&self, app: &mut App) {
-		app.add_plugins((TaperedCylinderRenderPlugin, NoisyCylinderRenderPlugin)).add_systems(
+		app.add_plugins((
+			TaperedCylinderRenderPlugin,
+			NoisyCylinderRenderPlugin,
+			CrookCylinderRenderPlugin,
+		))
+		.add_systems(
 			Update,
 			announcer::despawn_render_command_announcer
 				.after(react_render_helper_noisy_cylinder)
-				.after(react_render_helper_tapered_cylinder),
+				.after(react_render_helper_tapered_cylinder)
+				.after(react_render_helper_crook_cylinder),
 		);
 	}
 }

--- a/maybraid/sdf/common-playground/src/commands/render/plugin.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/plugin.rs
@@ -10,6 +10,9 @@ use super::crook_cylinder::plugin::{
 use super::noisy_cylinder::plugin::{
 	react_render_helper_noisy_cylinder, NoisyCylinderRenderPlugin,
 };
+use super::noisy_crook_cylinder::plugin::{
+	react_render_helper_noisy_crook_cylinder, NoisyCrookCylinderRenderPlugin,
+};
 use super::tapered_cylinder::plugin::{
 	react_render_helper_tapered_cylinder, TaperedCylinderRenderPlugin,
 };
@@ -24,13 +27,15 @@ impl Plugin for RenderCommandsPlugin {
 			TaperedCylinderRenderPlugin,
 			NoisyCylinderRenderPlugin,
 			CrookCylinderRenderPlugin,
+			NoisyCrookCylinderRenderPlugin,
 		))
 		.add_systems(
 			Update,
 			announcer::despawn_render_command_announcer
 				.after(react_render_helper_noisy_cylinder)
 				.after(react_render_helper_tapered_cylinder)
-				.after(react_render_helper_crook_cylinder),
+				.after(react_render_helper_crook_cylinder)
+				.after(react_render_helper_noisy_crook_cylinder),
 		);
 	}
 }

--- a/maybraid/sdf/common-playground/src/commands/render/plugin.rs
+++ b/maybraid/sdf/common-playground/src/commands/render/plugin.rs
@@ -4,9 +4,11 @@ mod announcer;
 
 use bevy::prelude::*;
 
+use super::ball::plugin::{react_render_helper_ball, BallRenderPlugin};
 use super::crook_cylinder::plugin::{
 	react_render_helper_crook_cylinder, CrookCylinderRenderPlugin,
 };
+use super::noisy_ball::plugin::{react_render_helper_noisy_ball, NoisyBallRenderPlugin};
 use super::noisy_cylinder::plugin::{
 	react_render_helper_noisy_cylinder, NoisyCylinderRenderPlugin,
 };
@@ -28,6 +30,8 @@ impl Plugin for RenderCommandsPlugin {
 			NoisyCylinderRenderPlugin,
 			CrookCylinderRenderPlugin,
 			NoisyCrookCylinderRenderPlugin,
+			BallRenderPlugin,
+			NoisyBallRenderPlugin,
 		))
 		.add_systems(
 			Update,
@@ -35,7 +39,9 @@ impl Plugin for RenderCommandsPlugin {
 				.after(react_render_helper_noisy_cylinder)
 				.after(react_render_helper_tapered_cylinder)
 				.after(react_render_helper_crook_cylinder)
-				.after(react_render_helper_noisy_crook_cylinder),
+				.after(react_render_helper_noisy_crook_cylinder)
+				.after(react_render_helper_ball)
+				.after(react_render_helper_noisy_ball),
 		);
 	}
 }

--- a/maybraid/sdf/common-playground/src/preview.rs
+++ b/maybraid/sdf/common-playground/src/preview.rs
@@ -33,6 +33,7 @@ fn preview_sync_key(config: &PreviewConfig) -> String {
 	let geom = match &config.primitive {
 		PlaygroundPrimitive::TaperedCylinder(c) => format!("t:{c:?}"),
 		PlaygroundPrimitive::NoisyCylinder(n) => format!("n:{:?}|{:?}", n.inner, n.noise),
+		PlaygroundPrimitive::CrookCylinder(c) => format!("k:{c:?}"),
 	};
 	format!(
 		"{geom}|{}|{:?}|{:?}",
@@ -63,6 +64,10 @@ pub fn keyboard_preview(
 		config.primitive = PlaygroundPrimitive::noisy_cylinder_default();
 		changed = true;
 	}
+	if keyboard.just_pressed(KeyCode::Digit3) {
+		config.primitive = PlaygroundPrimitive::crook_cylinder_default();
+		changed = true;
+	}
 	if keyboard.just_pressed(KeyCode::Equal) {
 		config.res_2 = (config.res_2 + 1).min(8);
 		changed = true;
@@ -84,7 +89,8 @@ pub fn keyboard_preview(
 fn next_primitive(current: &PlaygroundPrimitive) -> PlaygroundPrimitive {
 	match current {
 		PlaygroundPrimitive::TaperedCylinder(_) => PlaygroundPrimitive::noisy_cylinder_default(),
-		PlaygroundPrimitive::NoisyCylinder(_) => PlaygroundPrimitive::tapered_cylinder_default(),
+		PlaygroundPrimitive::NoisyCylinder(_) => PlaygroundPrimitive::crook_cylinder_default(),
+		PlaygroundPrimitive::CrookCylinder(_) => PlaygroundPrimitive::tapered_cylinder_default(),
 	}
 }
 

--- a/maybraid/sdf/common-playground/src/preview.rs
+++ b/maybraid/sdf/common-playground/src/preview.rs
@@ -37,6 +37,8 @@ fn preview_sync_key(config: &PreviewConfig) -> String {
 		PlaygroundPrimitive::NoisyCrookCylinder(n) => {
 			format!("nk:{:?}|{:?}", n.inner, n.noise)
 		}
+		PlaygroundPrimitive::Ball(b) => format!("b:{b:?}"),
+		PlaygroundPrimitive::NoisyBall(n) => format!("nb:{:?}|{:?}", n.inner, n.noise),
 	};
 	format!(
 		"{geom}|{}|{:?}|{:?}",
@@ -75,6 +77,14 @@ pub fn keyboard_preview(
 		config.primitive = PlaygroundPrimitive::noisy_crook_cylinder_default();
 		changed = true;
 	}
+	if keyboard.just_pressed(KeyCode::Digit5) {
+		config.primitive = PlaygroundPrimitive::ball_default();
+		changed = true;
+	}
+	if keyboard.just_pressed(KeyCode::Digit6) {
+		config.primitive = PlaygroundPrimitive::noisy_ball_default();
+		changed = true;
+	}
 	if keyboard.just_pressed(KeyCode::Equal) {
 		config.res_2 = (config.res_2 + 1).min(8);
 		changed = true;
@@ -98,7 +108,9 @@ fn next_primitive(current: &PlaygroundPrimitive) -> PlaygroundPrimitive {
 		PlaygroundPrimitive::TaperedCylinder(_) => PlaygroundPrimitive::noisy_cylinder_default(),
 		PlaygroundPrimitive::NoisyCylinder(_) => PlaygroundPrimitive::crook_cylinder_default(),
 		PlaygroundPrimitive::CrookCylinder(_) => PlaygroundPrimitive::noisy_crook_cylinder_default(),
-		PlaygroundPrimitive::NoisyCrookCylinder(_) => PlaygroundPrimitive::tapered_cylinder_default(),
+		PlaygroundPrimitive::NoisyCrookCylinder(_) => PlaygroundPrimitive::ball_default(),
+		PlaygroundPrimitive::Ball(_) => PlaygroundPrimitive::noisy_ball_default(),
+		PlaygroundPrimitive::NoisyBall(_) => PlaygroundPrimitive::tapered_cylinder_default(),
 	}
 }
 

--- a/maybraid/sdf/common-playground/src/preview.rs
+++ b/maybraid/sdf/common-playground/src/preview.rs
@@ -34,6 +34,9 @@ fn preview_sync_key(config: &PreviewConfig) -> String {
 		PlaygroundPrimitive::TaperedCylinder(c) => format!("t:{c:?}"),
 		PlaygroundPrimitive::NoisyCylinder(n) => format!("n:{:?}|{:?}", n.inner, n.noise),
 		PlaygroundPrimitive::CrookCylinder(c) => format!("k:{c:?}"),
+		PlaygroundPrimitive::NoisyCrookCylinder(n) => {
+			format!("nk:{:?}|{:?}", n.inner, n.noise)
+		}
 	};
 	format!(
 		"{geom}|{}|{:?}|{:?}",
@@ -68,6 +71,10 @@ pub fn keyboard_preview(
 		config.primitive = PlaygroundPrimitive::crook_cylinder_default();
 		changed = true;
 	}
+	if keyboard.just_pressed(KeyCode::Digit4) {
+		config.primitive = PlaygroundPrimitive::noisy_crook_cylinder_default();
+		changed = true;
+	}
 	if keyboard.just_pressed(KeyCode::Equal) {
 		config.res_2 = (config.res_2 + 1).min(8);
 		changed = true;
@@ -90,7 +97,8 @@ fn next_primitive(current: &PlaygroundPrimitive) -> PlaygroundPrimitive {
 	match current {
 		PlaygroundPrimitive::TaperedCylinder(_) => PlaygroundPrimitive::noisy_cylinder_default(),
 		PlaygroundPrimitive::NoisyCylinder(_) => PlaygroundPrimitive::crook_cylinder_default(),
-		PlaygroundPrimitive::CrookCylinder(_) => PlaygroundPrimitive::tapered_cylinder_default(),
+		PlaygroundPrimitive::CrookCylinder(_) => PlaygroundPrimitive::noisy_crook_cylinder_default(),
+		PlaygroundPrimitive::NoisyCrookCylinder(_) => PlaygroundPrimitive::tapered_cylinder_default(),
 	}
 }
 

--- a/maybraid/sdf/common-playground/src/primitive.rs
+++ b/maybraid/sdf/common-playground/src/primitive.rs
@@ -7,13 +7,14 @@ use render_item::{
 	NormalizeChunk, RenderItem,
 };
 use sdf::{Bounds, Sdf};
-use sdf_common::{NoisyCylinder, NoisySurface, TaperedCylinder};
+use sdf_common::{CrookCylinder, NoisyCylinder, NoisySurface, TaperedCylinder};
 
 /// Concrete SDF variants previewed in this playground.
 #[derive(Clone)]
 pub enum PlaygroundPrimitive {
 	TaperedCylinder(TaperedCylinder),
 	NoisyCylinder(NoisyCylinder),
+	CrookCylinder(CrookCylinder),
 }
 
 impl PlaygroundPrimitive {
@@ -30,15 +31,25 @@ impl PlaygroundPrimitive {
 		))
 	}
 
+	/// Visible bend for Tab cycling / key `3` (same radii as default taper).
+	pub fn crook_cylinder_default() -> Self {
+		Self::CrookCylinder(CrookCylinder {
+			bend_x: 0.12,
+			bend_z: 0.08,
+			..CrookCylinder::unit_segment(0.5, 0.4)
+		})
+	}
+
 	pub fn variant_key(&self) -> &'static str {
 		match self {
 			Self::TaperedCylinder(_) => "tapered-cylinder",
 			Self::NoisyCylinder(_) => "noisy-cylinder",
+			Self::CrookCylinder(_) => "crook-cylinder",
 		}
 	}
 
 	pub fn all_variant_keys() -> &'static [&'static str] {
-		&["tapered-cylinder", "noisy-cylinder"]
+		&["tapered-cylinder", "noisy-cylinder", "crook-cylinder"]
 	}
 
 	pub fn from_name(name: &str) -> Option<Self> {
@@ -47,6 +58,7 @@ impl PlaygroundPrimitive {
 				Some(Self::tapered_cylinder_default())
 			}
 			"noisy-cylinder" | "noisy" | "nc" | "2" => Some(Self::noisy_cylinder_default()),
+			"crook-cylinder" | "crook" | "cc" | "3" => Some(Self::crook_cylinder_default()),
 			_ => None,
 		}
 	}
@@ -57,6 +69,7 @@ impl std::fmt::Debug for PlaygroundPrimitive {
 		match self {
 			Self::TaperedCylinder(c) => f.debug_tuple("TaperedCylinder").field(c).finish(),
 			Self::NoisyCylinder(_) => f.write_str("NoisyCylinder(...)"),
+			Self::CrookCylinder(c) => f.debug_tuple("CrookCylinder").field(c).finish(),
 		}
 	}
 }
@@ -66,6 +79,7 @@ impl std::fmt::Display for PlaygroundPrimitive {
 		match self {
 			Self::TaperedCylinder(_) => write!(f, "TaperedCylinder"),
 			Self::NoisyCylinder(_) => write!(f, "NoisyCylinder"),
+			Self::CrookCylinder(_) => write!(f, "CrookCylinder"),
 		}
 	}
 }
@@ -75,6 +89,7 @@ impl Sdf for PlaygroundPrimitive {
 		match self {
 			Self::TaperedCylinder(c) => c.distance(p),
 			Self::NoisyCylinder(n) => n.distance(p),
+			Self::CrookCylinder(c) => c.distance(p),
 		}
 	}
 
@@ -82,6 +97,7 @@ impl Sdf for PlaygroundPrimitive {
 		match self {
 			Self::TaperedCylinder(c) => c.bounds(),
 			Self::NoisyCylinder(n) => n.bounds(),
+			Self::CrookCylinder(c) => c.bounds(),
 		}
 	}
 }
@@ -91,6 +107,7 @@ impl NormalizeChunk for PlaygroundPrimitive {
 		match self {
 			Self::TaperedCylinder(c) => c.normalize_chunk(cascade_chunk),
 			Self::NoisyCylinder(n) => n.normalize_chunk(cascade_chunk),
+			Self::CrookCylinder(c) => c.normalize_chunk(cascade_chunk),
 		}
 	}
 }
@@ -117,6 +134,18 @@ impl IdentifiedMesh for PlaygroundPrimitive {
 					p.noise_type,
 				))
 			}
+			Self::CrookCylinder(c) => MeshId::new(format!(
+				"playground.CrookCylinder:{}:{}:{}:{}:{}:{}:{}:{}:{}",
+				c.base_radius.to_bits(),
+				c.top_radius.to_bits(),
+				c.y_min.to_bits(),
+				c.height.to_bits(),
+				c.bounds_margin.to_bits(),
+				c.bend_x.to_bits(),
+				c.bend_z.to_bits(),
+				c.phase_x.to_bits(),
+				c.phase_z.to_bits(),
+			)),
 		}
 	}
 }

--- a/maybraid/sdf/common-playground/src/primitive.rs
+++ b/maybraid/sdf/common-playground/src/primitive.rs
@@ -8,8 +8,8 @@ use render_item::{
 };
 use sdf::{Bounds, Sdf};
 use sdf_common::{
-	CrookCylinder, NoisyCylinder, NoisyCrookCylinder, NoisySurface, TaperedCylinder,
-	UnitCylinderNoiseParams,
+	Ball, CrookCylinder, NoisyBall, NoisyCylinder, NoisyCrookCylinder, NoisySurface,
+	TaperedCylinder, UnitCylinderNoiseParams,
 };
 
 /// Concrete SDF variants previewed in this playground.
@@ -19,6 +19,8 @@ pub enum PlaygroundPrimitive {
 	NoisyCylinder(NoisyCylinder),
 	CrookCylinder(CrookCylinder),
 	NoisyCrookCylinder(NoisyCrookCylinder),
+	Ball(Ball),
+	NoisyBall(NoisyBall),
 }
 
 impl PlaygroundPrimitive {
@@ -57,12 +59,23 @@ impl PlaygroundPrimitive {
 		))
 	}
 
+	pub fn ball_default() -> Self {
+		Self::Ball(Ball::unit_sphere())
+	}
+
+	/// [`Ball::unit_sphere`] with Perlin noise (seed **42**, freq **5**, amp **0.05**) like [`Self::noisy_cylinder_default`].
+	pub fn noisy_ball_default() -> Self {
+		Self::NoisyBall(NoisySurface::new_perlin(Ball::unit_sphere(), 42, 5.0, 0.05))
+	}
+
 	pub fn variant_key(&self) -> &'static str {
 		match self {
 			Self::TaperedCylinder(_) => "tapered-cylinder",
 			Self::NoisyCylinder(_) => "noisy-cylinder",
 			Self::CrookCylinder(_) => "crook-cylinder",
 			Self::NoisyCrookCylinder(_) => "noisy-crook-cylinder",
+			Self::Ball(_) => "ball",
+			Self::NoisyBall(_) => "noisy-ball",
 		}
 	}
 
@@ -72,6 +85,8 @@ impl PlaygroundPrimitive {
 			"noisy-cylinder",
 			"crook-cylinder",
 			"noisy-crook-cylinder",
+			"ball",
+			"noisy-ball",
 		]
 	}
 
@@ -85,6 +100,8 @@ impl PlaygroundPrimitive {
 			"noisy-crook-cylinder" | "noisy-crook" | "ncc" | "4" => {
 				Some(Self::noisy_crook_cylinder_default())
 			}
+			"ball" | "sphere" | "b" | "5" => Some(Self::ball_default()),
+			"noisy-ball" | "noisy-sphere" | "nb" | "6" => Some(Self::noisy_ball_default()),
 			_ => None,
 		}
 	}
@@ -97,6 +114,8 @@ impl std::fmt::Debug for PlaygroundPrimitive {
 			Self::NoisyCylinder(_) => f.write_str("NoisyCylinder(...)"),
 			Self::CrookCylinder(c) => f.debug_tuple("CrookCylinder").field(c).finish(),
 			Self::NoisyCrookCylinder(_) => f.write_str("NoisyCrookCylinder(...)"),
+			Self::Ball(b) => f.debug_tuple("Ball").field(b).finish(),
+			Self::NoisyBall(_) => f.write_str("NoisyBall(...)"),
 		}
 	}
 }
@@ -108,6 +127,8 @@ impl std::fmt::Display for PlaygroundPrimitive {
 			Self::NoisyCylinder(_) => write!(f, "NoisyCylinder"),
 			Self::CrookCylinder(_) => write!(f, "CrookCylinder"),
 			Self::NoisyCrookCylinder(_) => write!(f, "NoisyCrookCylinder"),
+			Self::Ball(_) => write!(f, "Ball"),
+			Self::NoisyBall(_) => write!(f, "NoisyBall"),
 		}
 	}
 }
@@ -119,6 +140,8 @@ impl Sdf for PlaygroundPrimitive {
 			Self::NoisyCylinder(n) => n.distance(p),
 			Self::CrookCylinder(c) => c.distance(p),
 			Self::NoisyCrookCylinder(n) => n.distance(p),
+			Self::Ball(b) => b.distance(p),
+			Self::NoisyBall(n) => n.distance(p),
 		}
 	}
 
@@ -128,6 +151,8 @@ impl Sdf for PlaygroundPrimitive {
 			Self::NoisyCylinder(n) => n.bounds(),
 			Self::CrookCylinder(c) => c.bounds(),
 			Self::NoisyCrookCylinder(n) => n.bounds(),
+			Self::Ball(b) => b.bounds(),
+			Self::NoisyBall(n) => n.bounds(),
 		}
 	}
 }
@@ -139,6 +164,8 @@ impl NormalizeChunk for PlaygroundPrimitive {
 			Self::NoisyCylinder(n) => n.normalize_chunk(cascade_chunk),
 			Self::CrookCylinder(c) => c.normalize_chunk(cascade_chunk),
 			Self::NoisyCrookCylinder(n) => n.normalize_chunk(cascade_chunk),
+			Self::Ball(b) => b.normalize_chunk(cascade_chunk),
+			Self::NoisyBall(n) => n.normalize_chunk(cascade_chunk),
 		}
 	}
 }
@@ -191,6 +218,25 @@ impl IdentifiedMesh for PlaygroundPrimitive {
 					c.bend_z.to_bits(),
 					c.phase_x.to_bits(),
 					c.phase_z.to_bits(),
+					p.seed,
+					p.frequency.to_bits(),
+					p.amplitude.to_bits(),
+					p.octaves,
+					p.noise_type,
+				))
+			}
+			Self::Ball(b) => MeshId::new(format!(
+				"playground.Ball:{}:{}",
+				b.radius.to_bits(),
+				b.bounds_margin.to_bits(),
+			)),
+			Self::NoisyBall(n) => {
+				let b = &n.inner;
+				let p = &n.noise;
+				MeshId::new(format!(
+					"playground.NoisyBall:{}:{}:{}:{}:{}:{}:{:?}",
+					b.radius.to_bits(),
+					b.bounds_margin.to_bits(),
 					p.seed,
 					p.frequency.to_bits(),
 					p.amplitude.to_bits(),

--- a/maybraid/sdf/common-playground/src/primitive.rs
+++ b/maybraid/sdf/common-playground/src/primitive.rs
@@ -7,7 +7,10 @@ use render_item::{
 	NormalizeChunk, RenderItem,
 };
 use sdf::{Bounds, Sdf};
-use sdf_common::{CrookCylinder, NoisyCylinder, NoisySurface, TaperedCylinder};
+use sdf_common::{
+	CrookCylinder, NoisyCylinder, NoisyCrookCylinder, NoisySurface, TaperedCylinder,
+	UnitCylinderNoiseParams,
+};
 
 /// Concrete SDF variants previewed in this playground.
 #[derive(Clone)]
@@ -15,6 +18,7 @@ pub enum PlaygroundPrimitive {
 	TaperedCylinder(TaperedCylinder),
 	NoisyCylinder(NoisyCylinder),
 	CrookCylinder(CrookCylinder),
+	NoisyCrookCylinder(NoisyCrookCylinder),
 }
 
 impl PlaygroundPrimitive {
@@ -40,16 +44,35 @@ impl PlaygroundPrimitive {
 		})
 	}
 
+	/// Same crook as [`Self::crook_cylinder_default`] with [`UnitCylinderNoiseParams`] surface noise.
+	pub fn noisy_crook_cylinder_default() -> Self {
+		let crook = CrookCylinder {
+			bend_x: 0.12,
+			bend_z: 0.08,
+			..CrookCylinder::unit_segment(0.5, 0.4)
+		};
+		Self::NoisyCrookCylinder(NoisySurface::from_params(
+			crook,
+			UnitCylinderNoiseParams.into(),
+		))
+	}
+
 	pub fn variant_key(&self) -> &'static str {
 		match self {
 			Self::TaperedCylinder(_) => "tapered-cylinder",
 			Self::NoisyCylinder(_) => "noisy-cylinder",
 			Self::CrookCylinder(_) => "crook-cylinder",
+			Self::NoisyCrookCylinder(_) => "noisy-crook-cylinder",
 		}
 	}
 
 	pub fn all_variant_keys() -> &'static [&'static str] {
-		&["tapered-cylinder", "noisy-cylinder", "crook-cylinder"]
+		&[
+			"tapered-cylinder",
+			"noisy-cylinder",
+			"crook-cylinder",
+			"noisy-crook-cylinder",
+		]
 	}
 
 	pub fn from_name(name: &str) -> Option<Self> {
@@ -59,6 +82,9 @@ impl PlaygroundPrimitive {
 			}
 			"noisy-cylinder" | "noisy" | "nc" | "2" => Some(Self::noisy_cylinder_default()),
 			"crook-cylinder" | "crook" | "cc" | "3" => Some(Self::crook_cylinder_default()),
+			"noisy-crook-cylinder" | "noisy-crook" | "ncc" | "4" => {
+				Some(Self::noisy_crook_cylinder_default())
+			}
 			_ => None,
 		}
 	}
@@ -70,6 +96,7 @@ impl std::fmt::Debug for PlaygroundPrimitive {
 			Self::TaperedCylinder(c) => f.debug_tuple("TaperedCylinder").field(c).finish(),
 			Self::NoisyCylinder(_) => f.write_str("NoisyCylinder(...)"),
 			Self::CrookCylinder(c) => f.debug_tuple("CrookCylinder").field(c).finish(),
+			Self::NoisyCrookCylinder(_) => f.write_str("NoisyCrookCylinder(...)"),
 		}
 	}
 }
@@ -80,6 +107,7 @@ impl std::fmt::Display for PlaygroundPrimitive {
 			Self::TaperedCylinder(_) => write!(f, "TaperedCylinder"),
 			Self::NoisyCylinder(_) => write!(f, "NoisyCylinder"),
 			Self::CrookCylinder(_) => write!(f, "CrookCylinder"),
+			Self::NoisyCrookCylinder(_) => write!(f, "NoisyCrookCylinder"),
 		}
 	}
 }
@@ -90,6 +118,7 @@ impl Sdf for PlaygroundPrimitive {
 			Self::TaperedCylinder(c) => c.distance(p),
 			Self::NoisyCylinder(n) => n.distance(p),
 			Self::CrookCylinder(c) => c.distance(p),
+			Self::NoisyCrookCylinder(n) => n.distance(p),
 		}
 	}
 
@@ -98,6 +127,7 @@ impl Sdf for PlaygroundPrimitive {
 			Self::TaperedCylinder(c) => c.bounds(),
 			Self::NoisyCylinder(n) => n.bounds(),
 			Self::CrookCylinder(c) => c.bounds(),
+			Self::NoisyCrookCylinder(n) => n.bounds(),
 		}
 	}
 }
@@ -108,6 +138,7 @@ impl NormalizeChunk for PlaygroundPrimitive {
 			Self::TaperedCylinder(c) => c.normalize_chunk(cascade_chunk),
 			Self::NoisyCylinder(n) => n.normalize_chunk(cascade_chunk),
 			Self::CrookCylinder(c) => c.normalize_chunk(cascade_chunk),
+			Self::NoisyCrookCylinder(n) => n.normalize_chunk(cascade_chunk),
 		}
 	}
 }
@@ -146,6 +177,27 @@ impl IdentifiedMesh for PlaygroundPrimitive {
 				c.phase_x.to_bits(),
 				c.phase_z.to_bits(),
 			)),
+			Self::NoisyCrookCylinder(n) => {
+				let c = &n.inner;
+				let p = &n.noise;
+				MeshId::new(format!(
+					"playground.NoisyCrookCylinder:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{:?}",
+					c.base_radius.to_bits(),
+					c.top_radius.to_bits(),
+					c.y_min.to_bits(),
+					c.height.to_bits(),
+					c.bounds_margin.to_bits(),
+					c.bend_x.to_bits(),
+					c.bend_z.to_bits(),
+					c.phase_x.to_bits(),
+					c.phase_z.to_bits(),
+					p.seed,
+					p.frequency.to_bits(),
+					p.amplitude.to_bits(),
+					p.octaves,
+					p.noise_type,
+				))
+			}
 		}
 	}
 }

--- a/maybraid/sdf/common-playground/src/ui.rs
+++ b/maybraid/sdf/common-playground/src/ui.rs
@@ -60,7 +60,7 @@ pub fn setup_debug_ui(mut commands: Commands) {
 		))
 		.with_children(|parent| {
 			parent.spawn((
-				Text::new("SDF playground · Tab/1/2/3/4 · +/- res · / cmd · WASD · ↑↓ history · ⇧↑↓ scroll"),
+				Text::new("SDF playground · Tab/1–6 · +/- res · / cmd · WASD · ↑↓ history · ⇧↑↓ scroll"),
 				TextFont { font_size: status_size, ..default() },
 				TextColor(Color::WHITE),
 				HudStatusLine,

--- a/maybraid/sdf/common-playground/src/ui.rs
+++ b/maybraid/sdf/common-playground/src/ui.rs
@@ -60,7 +60,7 @@ pub fn setup_debug_ui(mut commands: Commands) {
 		))
 		.with_children(|parent| {
 			parent.spawn((
-				Text::new("SDF playground · Tab/1/2 · +/- res · / cmd · WASD · ↑↓ history · ⇧↑↓ scroll"),
+				Text::new("SDF playground · Tab/1/2/3 · +/- res · / cmd · WASD · ↑↓ history · ⇧↑↓ scroll"),
 				TextFont { font_size: status_size, ..default() },
 				TextColor(Color::WHITE),
 				HudStatusLine,

--- a/maybraid/sdf/common-playground/src/ui.rs
+++ b/maybraid/sdf/common-playground/src/ui.rs
@@ -60,7 +60,7 @@ pub fn setup_debug_ui(mut commands: Commands) {
 		))
 		.with_children(|parent| {
 			parent.spawn((
-				Text::new("SDF playground · Tab/1/2/3 · +/- res · / cmd · WASD · ↑↓ history · ⇧↑↓ scroll"),
+				Text::new("SDF playground · Tab/1/2/3/4 · +/- res · / cmd · WASD · ↑↓ history · ⇧↑↓ scroll"),
 				TextFont { font_size: status_size, ..default() },
 				TextColor(Color::WHITE),
 				HudStatusLine,

--- a/maybraid/sdf/common/src/ball.rs
+++ b/maybraid/sdf/common/src/ball.rs
@@ -1,0 +1,91 @@
+//! **Ball** — SDF sphere centered at the origin ([RFC-183 §3.1.2.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/02-ball-components/02-noisy-ball/README.md), [#213](https://github.com/ramate-io/maybraid/issues/213)).
+//!
+//! Pair with [`crate::noisy::NoisySurface`] for the RFC **noisy ball** composition ([`NoisyBall`](crate::noisy::NoisyBall)).
+
+use bevy::math::bounding::Aabb3d;
+use bevy::prelude::*;
+use chunk::cascade::CascadeChunk;
+use procedural_common::NUMERIC_SURFACE_EPSILON;
+use render_item::NormalizeChunk;
+use sdf::{Bounds, Sdf};
+
+/// Half-edge of [`CascadeChunk::unit_3d_center_chunk`] before [`CascadeChunk::with_mu`].
+const UNIT_3D_CENTER_HALF: f32 = 0.5;
+
+/// Solid sphere **centered at the origin**: inside is negative distance.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+#[cfg_attr(feature = "clap", command(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ball {
+	/// Radius (world units).
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.5))]
+	pub radius: f32,
+	/// Extra padding on the axis-aligned bounds cube (e.g. match chunk μ or mesh band).
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	pub bounds_margin: f32,
+}
+
+impl Default for Ball {
+	fn default() -> Self {
+		Self { radius: 0.5, bounds_margin: 0.0 }
+	}
+}
+
+impl Ball {
+	/// Sphere of radius `0.5` at the origin (inscribes the default [`CascadeChunk::unit_3d_center_chunk`] cube).
+	pub fn unit_sphere() -> Self {
+		Self { radius: 0.5, bounds_margin: 0.0 }
+	}
+}
+
+impl Sdf for Ball {
+	fn distance(&self, p: Vec3) -> f32 {
+		p.length() - self.radius
+	}
+
+	fn bounds(&self) -> Bounds {
+		let h = self.radius + self.bounds_margin;
+		let min = Vec3::splat(-h);
+		let max = Vec3::splat(h);
+		Bounds::Cuboid(Aabb3d::from_min_max(min, max))
+	}
+}
+
+impl NormalizeChunk for Ball {
+	fn normalize_chunk(&self, cascade_chunk: &CascadeChunk) -> CascadeChunk {
+		let h = self.radius + self.bounds_margin;
+		let mu = (h - UNIT_3D_CENTER_HALF).max(0.0) + NUMERIC_SURFACE_EPSILON;
+		CascadeChunk::unit_3d_center_chunk().with_res_2(cascade_chunk.res_2).with_mu(mu)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn unit_sphere_inside_negative() -> Result<()> {
+		let b = Ball::unit_sphere();
+		assert!(b.distance(Vec3::ZERO) < 0.0);
+		assert!(b.distance(Vec3::new(0.5, 0.0, 0.0)).abs() < 1e-5);
+		Ok(())
+	}
+
+	#[test]
+	fn bounds_cube_half_size() -> Result<()> {
+		let b = Ball {
+			radius: 0.4,
+			bounds_margin: 0.02,
+		};
+		if let Bounds::Cuboid(a) = b.bounds() {
+			let e = 0.42;
+			assert!((a.min.x + e).abs() < 1e-5);
+			assert!((a.max.x - e).abs() < 1e-5);
+		} else {
+			panic!("expected cuboid bounds");
+		}
+		Ok(())
+	}
+}

--- a/maybraid/sdf/common/src/crook_cylinder.rs
+++ b/maybraid/sdf/common/src/crook_cylinder.rs
@@ -18,9 +18,9 @@ use crate::cylinder::TaperedCylinder;
 
 /// Extra horizontal half-extent (beyond `|bend| + max_radius`) so tilted tube cross-sections and the
 /// approximate closest-spine field do not clip marching-cubes meshes.
-const BOUNDS_XZ_SLACK_PER_RADIUS: f32 = 0.55;
+const BOUNDS_XZ_SLACK_PER_RADIUS: f32 = 0.0;
 /// Additional slack on **each** of X and Z tied to total bend magnitude (coupled bulge).
-const BOUNDS_XZ_SLACK_PER_BEND_SUM: f32 = 0.2;
+const BOUNDS_XZ_SLACK_PER_BEND_SUM: f32 = 0.0;
 
 /// [`CascadeChunk::unit_center_chunk`] spans XZ ∈ [−0.5, 0.5] before [`CascadeChunk::with_mu`].
 const UNIT_CENTER_CHUNK_XZ_HALF: f32 = 0.5;

--- a/maybraid/sdf/common/src/crook_cylinder.rs
+++ b/maybraid/sdf/common/src/crook_cylinder.rs
@@ -16,6 +16,12 @@ use sdf::{Bounds, Sdf};
 
 use crate::cylinder::TaperedCylinder;
 
+/// Extra horizontal half-extent (beyond `|bend| + max_radius`) so tilted tube cross-sections and the
+/// approximate closest-spine field do not clip marching-cubes meshes.
+const BOUNDS_XZ_SLACK_PER_RADIUS: f32 = 0.55;
+/// Additional slack on **each** of X and Z tied to total bend magnitude (coupled bulge).
+const BOUNDS_XZ_SLACK_PER_BEND_SUM: f32 = 0.2;
+
 /// Tapered cylinder segment with a smooth bent centerline (capped in **world Y** like [`TaperedCylinder`]).
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "clap", derive(clap::Args))]
@@ -98,6 +104,19 @@ impl CrookCylinder {
 		}
 	}
 
+	/// Axis-aligned half-width in **X** and **Z** for [`Sdf::bounds`] (liberal envelope around the bent tube).
+	fn bounds_xz_half_extents(&self) -> (f32, f32) {
+		let r = self.base_radius.max(self.top_radius);
+		let m = self.bounds_margin;
+		let bx = self.bend_x.abs();
+		let bz = self.bend_z.abs();
+		let slack_r = r * BOUNDS_XZ_SLACK_PER_RADIUS;
+		let slack_bend = BOUNDS_XZ_SLACK_PER_BEND_SUM * (bx + bz);
+		let half_x = bx + r + slack_r + slack_bend + m;
+		let half_z = bz + r + slack_r + slack_bend + m;
+		(half_x, half_z)
+	}
+
 	/// Centerline position in world space for normalized parameter `t ∈ [0, 1]`.
 	#[inline]
 	pub fn centerline(&self, t: f32) -> Vec3 {
@@ -172,12 +191,10 @@ impl Sdf for CrookCylinder {
 	}
 
 	fn bounds(&self) -> Bounds {
-		let r = self.base_radius.max(self.top_radius);
 		let m = self.bounds_margin;
-		let bx = self.bend_x.abs();
-		let bz = self.bend_z.abs();
-		let min = Vec3::new(-r - bx - m, self.y_min - m, -r - bz - m);
-		let max = Vec3::new(r + bx + m, self.y_min + self.height + m, r + bz + m);
+		let (half_x, half_z) = self.bounds_xz_half_extents();
+		let min = Vec3::new(-half_x, self.y_min - m, -half_z);
+		let max = Vec3::new(half_x, self.y_min + self.height + m, half_z);
 		Bounds::Cuboid(Aabb3d::from_min_max(min, max))
 	}
 }
@@ -238,6 +255,23 @@ mod tests {
 		let c = CrookCylinder::unit_segment(0.5, 0.4);
 		let d = c.distance(Vec3::new(50.0, 0.5, 0.0));
 		assert!(d > 0.0);
+		Ok(())
+	}
+
+	#[test]
+	fn bounds_xz_liberal_vs_tight_envelope() -> Result<()> {
+		let c = CrookCylinder {
+			bend_x: 0.15,
+			bend_z: 0.1,
+			..CrookCylinder::unit_segment(0.5, 0.4)
+		};
+		let r = c.base_radius.max(c.top_radius);
+		let tight = r + c.bend_x.abs() + c.bounds_margin;
+		let (half_x, _) = c.bounds_xz_half_extents();
+		assert!(
+			half_x > tight + r * 0.4,
+			"expected liberal XZ bounds (got {half_x}, tight spine+radius {tight})"
+		);
 		Ok(())
 	}
 }

--- a/maybraid/sdf/common/src/crook_cylinder.rs
+++ b/maybraid/sdf/common/src/crook_cylinder.rs
@@ -1,0 +1,243 @@
+//! **Crook cylinder** — tapered segment with a smooth sinusoidal centerline ([RFC-183 §3.1.1.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/01-stick-and-stalk-components/02-crook-cylinder/README.md), [#211](https://github.com/ramate-io/maybraid/issues/211)).
+//!
+//! Local space matches [`crate::cylinder::TaperedCylinder`]: **Y** runs along the nominal axis from [`CrookCylinder::y_min`] through [`CrookCylinder::height`]. The spine is offset in **X** and **Z** by
+//! `bend_x * sin(π t + φ_x)` and `bend_z * sin(π t + φ_z)` with `t ∈ [0,1]` along the segment.
+//!
+//! Pair with [`crate::noisy::NoisySurface`] for the RFC **noisy crook cylinder** composition ([`NoisyCrookCylinder`](crate::noisy::NoisyCrookCylinder)).
+
+use std::f32::consts::PI;
+
+use bevy::math::bounding::Aabb3d;
+use bevy::prelude::*;
+use chunk::cascade::CascadeChunk;
+use procedural_common::NUMERIC_SURFACE_EPSILON;
+use render_item::NormalizeChunk;
+use sdf::{Bounds, Sdf};
+
+use crate::cylinder::TaperedCylinder;
+
+/// Tapered cylinder segment with a smooth bent centerline (capped in **world Y** like [`TaperedCylinder`]).
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+#[cfg_attr(feature = "clap", command(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CrookCylinder {
+	/// Radius at `y = y_min` (bottom of the segment).
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.5))]
+	pub base_radius: f32,
+	/// Radius at `y = y_min + height` (top of the segment).
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.4))]
+	pub top_radius: f32,
+	/// Lower extent of the finite cylinder along Y.
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	pub y_min: f32,
+	/// Segment length along Y (must be positive).
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 1.0))]
+	pub height: f32,
+	/// Extra **uniform** padding on the axis-aligned bounds.
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	pub bounds_margin: f32,
+	/// Bend amplitude in **X** (same units as radius; multiplies `sin(π t + phase_x)`).
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	pub bend_x: f32,
+	/// Bend amplitude in **Z**.
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	pub bend_z: f32,
+	/// Phase offset for the X bend (radians).
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	pub phase_x: f32,
+	/// Phase offset for the Z bend (radians).
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	pub phase_z: f32,
+}
+
+impl Default for CrookCylinder {
+	fn default() -> Self {
+		Self {
+			base_radius: 0.5,
+			top_radius: 0.4,
+			y_min: 0.0,
+			height: 1.0,
+			bounds_margin: 0.0,
+			bend_x: 0.0,
+			bend_z: 0.0,
+			phase_x: 0.0,
+			phase_z: 0.0,
+		}
+	}
+}
+
+impl CrookCylinder {
+	/// Unit-height segment `[y_min, y_min + 1]` with straight spine (same as [`TaperedCylinder::unit_segment`] when bends are zero).
+	pub fn unit_segment(base_radius: f32, top_radius: f32) -> Self {
+		Self {
+			base_radius,
+			top_radius,
+			y_min: 0.0,
+			height: 1.0,
+			bounds_margin: 0.0,
+			bend_x: 0.0,
+			bend_z: 0.0,
+			phase_x: 0.0,
+			phase_z: 0.0,
+		}
+	}
+
+	/// Same radii / height / `y_min` / margin as `taper`, with explicit bend parameters.
+	pub fn from_tapered(taper: TaperedCylinder, bend_x: f32, bend_z: f32, phase_x: f32, phase_z: f32) -> Self {
+		Self {
+			base_radius: taper.base_radius,
+			top_radius: taper.top_radius,
+			y_min: taper.y_min,
+			height: taper.height,
+			bounds_margin: taper.bounds_margin,
+			bend_x,
+			bend_z,
+			phase_x,
+			phase_z,
+		}
+	}
+
+	/// Centerline position in world space for normalized parameter `t ∈ [0, 1]`.
+	#[inline]
+	pub fn centerline(&self, t: f32) -> Vec3 {
+		let u = t.clamp(0.0, 1.0);
+		let y = self.y_min + u * self.height;
+		let a = PI * u;
+		Vec3::new(
+			self.bend_x * (a + self.phase_x).sin(),
+			y,
+			self.bend_z * (a + self.phase_z).sin(),
+		)
+	}
+
+	/// Derivative `dγ/du` for `u ∈ [0, 1]`.
+	#[inline]
+	fn centerline_dt(&self, u: f32) -> Vec3 {
+		let u = u.clamp(0.0, 1.0);
+		let a = PI * u;
+		let ca = (a + self.phase_x).cos() * PI;
+		let cz = (a + self.phase_z).cos() * PI;
+		Vec3::new(self.bend_x * ca, self.height, self.bend_z * cz)
+	}
+
+	/// Radius at normalized height `u ∈ [0, 1]`.
+	#[inline]
+	fn radius_at(&self, u: f32) -> f32 {
+		let u = u.clamp(0.0, 1.0);
+		self.base_radius * (1.0 - u) + self.top_radius * u
+	}
+
+	/// Approximate closest `u ∈ [0,1]` minimizing `‖p − γ(u)‖²` (fixed iterations, deterministic).
+	fn closest_u(&self, p: Vec3) -> f32 {
+		let h = self.height.max(1e-6);
+		let mut u = ((p.y - self.y_min) / h).clamp(0.0, 1.0);
+		for _ in 0..12 {
+			let c = self.centerline(u);
+			let g = self.centerline_dt(u);
+			let denom = g.dot(g).max(1e-20);
+			u = (u + (p - c).dot(g) / denom).clamp(0.0, 1.0);
+		}
+		u
+	}
+
+	fn lateral_shell_distance(&self, p: Vec3) -> f32 {
+		let u = self.closest_u(p);
+		let c = self.centerline(u);
+		let g = self.centerline_dt(u);
+		let gl = g.length();
+		let tangent = if gl > 1e-8 { g / gl } else { Vec3::Y };
+		let w = p - c;
+		let along = w.dot(tangent);
+		let perp = (w - tangent * along).length();
+		perp - self.radius_at(u)
+	}
+}
+
+impl Sdf for CrookCylinder {
+	fn distance(&self, p: Vec3) -> f32 {
+		let y = p.y;
+		let y0 = self.y_min;
+		let y1 = self.y_min + self.height;
+
+		let mut dist = self.lateral_shell_distance(p);
+
+		if y < y0 {
+			dist = dist.max(y0 - y);
+		} else if y > y1 {
+			dist = dist.max(y - y1);
+		}
+
+		dist
+	}
+
+	fn bounds(&self) -> Bounds {
+		let r = self.base_radius.max(self.top_radius);
+		let m = self.bounds_margin;
+		let bx = self.bend_x.abs();
+		let bz = self.bend_z.abs();
+		let min = Vec3::new(-r - bx - m, self.y_min - m, -r - bz - m);
+		let max = Vec3::new(r + bx + m, self.y_min + self.height + m, r + bz + m);
+		Bounds::Cuboid(Aabb3d::from_min_max(min, max))
+	}
+}
+
+impl NormalizeChunk for CrookCylinder {
+	fn normalize_chunk(&self, cascade_chunk: &CascadeChunk) -> CascadeChunk {
+		let mu = self.bounds_margin + NUMERIC_SURFACE_EPSILON;
+		CascadeChunk::unit_center_chunk().with_res_2(cascade_chunk.res_2).with_mu(mu)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn zero_bend_matches_tapered_on_axis() -> Result<()> {
+		let taper = TaperedCylinder::unit_segment(0.5, 0.4);
+		let crook = CrookCylinder::from_tapered(taper, 0.0, 0.0, 0.0, 0.0);
+		let p = Vec3::new(0.0, 0.5, 0.0);
+		let dt = (crook.distance(p) - taper.distance(p)).abs();
+		assert!(dt < 5e-3, "expected near match with straight taper, got delta {dt}");
+		Ok(())
+	}
+
+	#[test]
+	fn bent_spine_offset_inside() -> Result<()> {
+		let c = CrookCylinder {
+			bend_x: 0.1,
+			bend_z: -0.05,
+			phase_x: 0.3,
+			phase_z: -0.7,
+			..CrookCylinder::unit_segment(0.5, 0.4)
+		};
+		let u = 0.5_f32;
+		let spine = c.centerline(u);
+		let g = c.centerline_dt(u);
+		let t = if g.length_squared() > 1e-12 {
+			g.normalize()
+		} else {
+			Vec3::Y
+		};
+		let mut perp = t.cross(Vec3::Y);
+		if perp.length_squared() < 1e-12 {
+			perp = t.cross(Vec3::X);
+		}
+		let perp = perp.normalize();
+		let r = c.base_radius * 0.5 + c.top_radius * 0.5;
+		let p = spine + perp * (r * 0.5);
+		let d = c.distance(p);
+		assert!(d < 0.0, "point offset from spine inside radius should be negative, got {d}");
+		Ok(())
+	}
+
+	#[test]
+	fn far_point_outside() -> Result<()> {
+		let c = CrookCylinder::unit_segment(0.5, 0.4);
+		let d = c.distance(Vec3::new(50.0, 0.5, 0.0));
+		assert!(d > 0.0);
+		Ok(())
+	}
+}

--- a/maybraid/sdf/common/src/crook_cylinder.rs
+++ b/maybraid/sdf/common/src/crook_cylinder.rs
@@ -272,16 +272,15 @@ mod tests {
 	}
 
 	#[test]
-	fn bounds_xz_liberal_vs_tight_envelope() -> Result<()> {
+	fn bounds_xz_match_bend_plus_radius() -> Result<()> {
 		let c =
 			CrookCylinder { bend_x: 0.15, bend_z: 0.1, ..CrookCylinder::unit_segment(0.5, 0.4) };
 		let r = c.base_radius.max(c.top_radius);
-		let tight = r + c.bend_x.abs() + c.bounds_margin;
-		let (half_x, _) = c.bounds_xz_half_extents();
-		assert!(
-			half_x > tight + r * 0.4,
-			"expected liberal XZ bounds (got {half_x}, tight spine+radius {tight})"
-		);
+		let (half_x, half_z) = c.bounds_xz_half_extents();
+		let ex = c.bend_x.abs() + r + c.bounds_margin;
+		let ez = c.bend_z.abs() + r + c.bounds_margin;
+		assert!((half_x - ex).abs() < 1e-5, "half_x={half_x} ex={ex}");
+		assert!((half_z - ez).abs() < 1e-5, "half_z={half_z} ez={ez}");
 		Ok(())
 	}
 

--- a/maybraid/sdf/common/src/crook_cylinder.rs
+++ b/maybraid/sdf/common/src/crook_cylinder.rs
@@ -22,6 +22,9 @@ const BOUNDS_XZ_SLACK_PER_RADIUS: f32 = 0.55;
 /// Additional slack on **each** of X and Z tied to total bend magnitude (coupled bulge).
 const BOUNDS_XZ_SLACK_PER_BEND_SUM: f32 = 0.2;
 
+/// [`CascadeChunk::unit_center_chunk`] spans XZ ∈ [−0.5, 0.5] before [`CascadeChunk::with_mu`].
+const UNIT_CENTER_CHUNK_XZ_HALF: f32 = 0.5;
+
 /// Tapered cylinder segment with a smooth bent centerline (capped in **world Y** like [`TaperedCylinder`]).
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "clap", derive(clap::Args))]
@@ -44,10 +47,10 @@ pub struct CrookCylinder {
 	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
 	pub bounds_margin: f32,
 	/// Bend amplitude in **X** (same units as radius; multiplies `sin(π t + phase_x)`).
-	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.15))]
 	pub bend_x: f32,
 	/// Bend amplitude in **Z**.
-	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
+	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.1))]
 	pub bend_z: f32,
 	/// Phase offset for the X bend (radians).
 	#[cfg_attr(feature = "clap", arg(long, default_value_t = 0.0))]
@@ -90,7 +93,13 @@ impl CrookCylinder {
 	}
 
 	/// Same radii / height / `y_min` / margin as `taper`, with explicit bend parameters.
-	pub fn from_tapered(taper: TaperedCylinder, bend_x: f32, bend_z: f32, phase_x: f32, phase_z: f32) -> Self {
+	pub fn from_tapered(
+		taper: TaperedCylinder,
+		bend_x: f32,
+		bend_z: f32,
+		phase_x: f32,
+		phase_z: f32,
+	) -> Self {
 		Self {
 			base_radius: taper.base_radius,
 			top_radius: taper.top_radius,
@@ -117,17 +126,23 @@ impl CrookCylinder {
 		(half_x, half_z)
 	}
 
+	/// Extra `μ` for [`CascadeChunk::with_mu`] so marching cubes sample past the default unit-center
+	/// XZ half-width ([`UNIT_CENTER_CHUNK_XZ_HALF`]) when the crook bulges beyond ±0.5.
+	///
+	/// [`Sdf::bounds`] does not resize the extraction grid; only [`NormalizeChunk`] does.
+	pub fn chunk_mu_xz_pad(&self) -> f32 {
+		let (hx, hz) = self.bounds_xz_half_extents();
+		let max_half = hx.max(hz);
+		(max_half - UNIT_CENTER_CHUNK_XZ_HALF).max(0.0) + NUMERIC_SURFACE_EPSILON
+	}
+
 	/// Centerline position in world space for normalized parameter `t ∈ [0, 1]`.
 	#[inline]
 	pub fn centerline(&self, t: f32) -> Vec3 {
 		let u = t.clamp(0.0, 1.0);
 		let y = self.y_min + u * self.height;
 		let a = PI * u;
-		Vec3::new(
-			self.bend_x * (a + self.phase_x).sin(),
-			y,
-			self.bend_z * (a + self.phase_z).sin(),
-		)
+		Vec3::new(self.bend_x * (a + self.phase_x).sin(), y, self.bend_z * (a + self.phase_z).sin())
 	}
 
 	/// Derivative `dγ/du` for `u ∈ [0, 1]`.
@@ -201,8 +216,10 @@ impl Sdf for CrookCylinder {
 
 impl NormalizeChunk for CrookCylinder {
 	fn normalize_chunk(&self, cascade_chunk: &CascadeChunk) -> CascadeChunk {
-		let mu = self.bounds_margin + NUMERIC_SURFACE_EPSILON;
-		CascadeChunk::unit_center_chunk().with_res_2(cascade_chunk.res_2).with_mu(mu)
+		let mu_xz = self.chunk_mu_xz_pad();
+		// Keep Y padding small so the segment stays grounded near **y = 0**; XZ use [`chunk_mu_xz_pad`].
+		let mu_y = self.bounds_margin + NUMERIC_SURFACE_EPSILON;
+		CascadeChunk::unit_center_chunk_with_mu_xz_y(mu_xz, mu_y).with_res_2(cascade_chunk.res_2)
 	}
 }
 
@@ -233,11 +250,7 @@ mod tests {
 		let u = 0.5_f32;
 		let spine = c.centerline(u);
 		let g = c.centerline_dt(u);
-		let t = if g.length_squared() > 1e-12 {
-			g.normalize()
-		} else {
-			Vec3::Y
-		};
+		let t = if g.length_squared() > 1e-12 { g.normalize() } else { Vec3::Y };
 		let mut perp = t.cross(Vec3::Y);
 		if perp.length_squared() < 1e-12 {
 			perp = t.cross(Vec3::X);
@@ -260,17 +273,26 @@ mod tests {
 
 	#[test]
 	fn bounds_xz_liberal_vs_tight_envelope() -> Result<()> {
-		let c = CrookCylinder {
-			bend_x: 0.15,
-			bend_z: 0.1,
-			..CrookCylinder::unit_segment(0.5, 0.4)
-		};
+		let c =
+			CrookCylinder { bend_x: 0.15, bend_z: 0.1, ..CrookCylinder::unit_segment(0.5, 0.4) };
 		let r = c.base_radius.max(c.top_radius);
 		let tight = r + c.bend_x.abs() + c.bounds_margin;
 		let (half_x, _) = c.bounds_xz_half_extents();
 		assert!(
 			half_x > tight + r * 0.4,
 			"expected liberal XZ bounds (got {half_x}, tight spine+radius {tight})"
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn chunk_mu_expands_when_bulge_exceeds_unit_cube() -> Result<()> {
+		let straight = CrookCylinder::unit_segment(0.5, 0.4);
+		let bent =
+			CrookCylinder { bend_x: 0.2, bend_z: 0.15, ..CrookCylinder::unit_segment(0.5, 0.4) };
+		assert!(
+			bent.chunk_mu_xz_pad() > straight.chunk_mu_xz_pad() + 0.05,
+			"bent crook should need larger chunk mu than straight"
 		);
 		Ok(())
 	}

--- a/maybraid/sdf/common/src/lib.rs
+++ b/maybraid/sdf/common/src/lib.rs
@@ -3,8 +3,9 @@
 //! This crate layers reusable geometry on top of workspace [`sdf`] ([`sdf::Sdf`]):
 //!
 //! - [`TaperedCylinder`](crate::cylinder::TaperedCylinder) — tapered capped cylinder (stick / trunk segment).
+//! - [`CrookCylinder`](crate::crook_cylinder::CrookCylinder) — tapered segment with smooth sinusoidal centerline ([RFC-183 §3.1.1.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/01-stick-and-stalk-components/02-crook-cylinder/README.md), [#211](https://github.com/ramate-io/maybraid/issues/211)).
 //! - [`NoisySurface`](crate::noisy::NoisySurface) — displacement from [`NoiseParams`](procedural_common::NoiseParams) via FastNoise Lite.
-//! - [`NoisyCylinder`](crate::noisy::NoisyCylinder) — convenience alias for a noisy tapered cylinder ([#210](https://github.com/ramate-io/maybraid/issues/210)).
+//! - [`NoisyCylinder`](crate::noisy::NoisyCylinder) / [`NoisyCrookCylinder`](crate::noisy::NoisyCrookCylinder) — noisy tapered / crook cylinders ([#210](https://github.com/ramate-io/maybraid/issues/210), [#211](https://github.com/ramate-io/maybraid/issues/211)).
 //!
 //! Optional **`clap`** / **`serde`** features add CLI and serialization derives on geometry and noise params.
 
@@ -12,8 +13,10 @@ pub use sdf;
 
 pub use procedural_common::{FromScalarNoise, NoiseConfig, NoiseParams, sdf_band_margin};
 
+pub mod crook_cylinder;
 pub mod cylinder;
 pub mod noisy;
 
+pub use crook_cylinder::CrookCylinder;
 pub use cylinder::TaperedCylinder;
-pub use noisy::{NoisyCylinder, NoisySurface, UnitCylinderNoiseParams};
+pub use noisy::{NoisyCrookCylinder, NoisyCylinder, NoisySurface, UnitCylinderNoiseParams};

--- a/maybraid/sdf/common/src/lib.rs
+++ b/maybraid/sdf/common/src/lib.rs
@@ -5,7 +5,9 @@
 //! - [`TaperedCylinder`](crate::cylinder::TaperedCylinder) — tapered capped cylinder (stick / trunk segment).
 //! - [`CrookCylinder`](crate::crook_cylinder::CrookCylinder) — tapered segment with smooth sinusoidal centerline ([RFC-183 §3.1.1.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/01-stick-and-stalk-components/02-crook-cylinder/README.md), [#211](https://github.com/ramate-io/maybraid/issues/211)).
 //! - [`NoisySurface`](crate::noisy::NoisySurface) — displacement from [`NoiseParams`](procedural_common::NoiseParams) via FastNoise Lite.
+//! - [`Ball`](crate::ball::Ball) — solid sphere centered at the origin ([RFC-183 §3.1.2.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/02-ball-components/02-noisy-ball/README.md), [#213](https://github.com/ramate-io/maybraid/issues/213)).
 //! - [`NoisyCylinder`](crate::noisy::NoisyCylinder) / [`NoisyCrookCylinder`](crate::noisy::NoisyCrookCylinder) — noisy tapered / crook cylinders ([#210](https://github.com/ramate-io/maybraid/issues/210), [#211](https://github.com/ramate-io/maybraid/issues/211)).
+//! - [`NoisyBall`](crate::noisy::NoisyBall) — noisy sphere (same RFC / issue).
 //!
 //! Optional **`clap`** / **`serde`** features add CLI and serialization derives on geometry and noise params.
 
@@ -13,10 +15,15 @@ pub use sdf;
 
 pub use procedural_common::{FromScalarNoise, NoiseConfig, NoiseParams, sdf_band_margin};
 
+pub mod ball;
 pub mod crook_cylinder;
 pub mod cylinder;
 pub mod noisy;
 
+pub use ball::Ball;
 pub use crook_cylinder::CrookCylinder;
 pub use cylinder::TaperedCylinder;
-pub use noisy::{NoisyCrookCylinder, NoisyCylinder, NoisySurface, UnitCylinderNoiseParams};
+pub use noisy::{
+	NoisyBall, NoisyCrookCylinder, NoisyCylinder, NoisySurface, UnitBallNoiseParams,
+	UnitCylinderNoiseParams,
+};

--- a/maybraid/sdf/common/src/noisy.rs
+++ b/maybraid/sdf/common/src/noisy.rs
@@ -14,11 +14,14 @@ use render_item::NormalizeChunk;
 use sdf::Bounds;
 use sdf::Sdf;
 
+use crate::ball::Ball;
 use crate::crook_cylinder::CrookCylinder;
 use crate::cylinder::TaperedCylinder;
 
+pub mod unit_ball;
 pub mod unit_cylinder;
 
+pub use unit_ball::UnitBallNoiseParams;
 pub use unit_cylinder::UnitCylinderNoiseParams;
 
 fn inflate_cuboid_bounds(aabb: Aabb3d, margin: f32) -> Aabb3d {
@@ -135,6 +138,19 @@ impl NormalizeChunk for NoisyCrookCylinder {
 	}
 }
 
+/// [`NoisySurface`] over [`Ball`] — RFC-183 **noisy ball** primitive ([#213](https://github.com/ramate-io/maybraid/issues/213)).
+pub type NoisyBall = NoisySurface<Ball>;
+
+impl NormalizeChunk for NoisyBall {
+	fn normalize_chunk(&self, cascade_chunk: &CascadeChunk) -> CascadeChunk {
+		let m = sdf_band_margin(&self.noise);
+		let h = self.inner.radius + self.inner.bounds_margin + m;
+		let half = 0.5_f32;
+		let mu = (h - half).max(0.0) + NUMERIC_SURFACE_EPSILON;
+		CascadeChunk::unit_3d_center_chunk().with_res_2(cascade_chunk.res_2).with_mu(mu)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -145,6 +161,16 @@ mod tests {
 	#[test]
 	fn unit_cylinder_noise_preset() -> Result<()> {
 		let p: NoiseParams = UnitCylinderNoiseParams.into();
+		assert_eq!(p.amplitude, 0.05);
+		assert_eq!(p.frequency, 5.0);
+		assert_eq!(p.octaves, 1);
+		assert_eq!(p.noise_type, NoiseType::Perlin);
+		Ok(())
+	}
+
+	#[test]
+	fn unit_ball_noise_preset() -> Result<()> {
+		let p: NoiseParams = UnitBallNoiseParams.into();
 		assert_eq!(p.amplitude, 0.05);
 		assert_eq!(p.frequency, 5.0);
 		assert_eq!(p.octaves, 1);

--- a/maybraid/sdf/common/src/noisy.rs
+++ b/maybraid/sdf/common/src/noisy.rs
@@ -7,7 +7,9 @@ use bevy::math::bounding::Aabb3d;
 use bevy::math::Vec3A;
 use bevy::prelude::*;
 use chunk::cascade::CascadeChunk;
-use procedural_common::{sdf_band_margin, NoiseConfig, NoiseParams, NoiseType};
+use procedural_common::{
+	sdf_band_margin, NoiseConfig, NoiseParams, NoiseType, NUMERIC_SURFACE_EPSILON,
+};
 use render_item::NormalizeChunk;
 use sdf::Bounds;
 use sdf::Sdf;
@@ -126,8 +128,10 @@ pub type NoisyCrookCylinder = NoisySurface<CrookCylinder>;
 
 impl NormalizeChunk for NoisyCrookCylinder {
 	fn normalize_chunk(&self, cascade_chunk: &CascadeChunk) -> CascadeChunk {
-		let mu = sdf_band_margin(&self.noise);
-		CascadeChunk::unit_center_chunk().with_res_2(cascade_chunk.res_2).with_mu(mu)
+		let m = sdf_band_margin(&self.noise);
+		let mu_xz = self.inner.chunk_mu_xz_pad() + m;
+		let mu_y = m + self.inner.bounds_margin + NUMERIC_SURFACE_EPSILON;
+		CascadeChunk::unit_center_chunk_with_mu_xz_y(mu_xz, mu_y).with_res_2(cascade_chunk.res_2)
 	}
 }
 

--- a/maybraid/sdf/common/src/noisy.rs
+++ b/maybraid/sdf/common/src/noisy.rs
@@ -12,6 +12,7 @@ use render_item::NormalizeChunk;
 use sdf::Bounds;
 use sdf::Sdf;
 
+use crate::crook_cylinder::CrookCylinder;
 use crate::cylinder::TaperedCylinder;
 
 pub mod unit_cylinder;
@@ -114,6 +115,16 @@ impl<S: Clone> Clone for NoisySurface<S> {
 pub type NoisyCylinder = NoisySurface<TaperedCylinder>;
 
 impl NormalizeChunk for NoisyCylinder {
+	fn normalize_chunk(&self, cascade_chunk: &CascadeChunk) -> CascadeChunk {
+		let mu = sdf_band_margin(&self.noise);
+		CascadeChunk::unit_center_chunk().with_res_2(cascade_chunk.res_2).with_mu(mu)
+	}
+}
+
+/// [`NoisySurface`] over [`CrookCylinder`] — RFC-183 **noisy crook cylinder** ([#211](https://github.com/ramate-io/maybraid/issues/211)).
+pub type NoisyCrookCylinder = NoisySurface<CrookCylinder>;
+
+impl NormalizeChunk for NoisyCrookCylinder {
 	fn normalize_chunk(&self, cascade_chunk: &CascadeChunk) -> CascadeChunk {
 		let mu = sdf_band_margin(&self.noise);
 		CascadeChunk::unit_center_chunk().with_res_2(cascade_chunk.res_2).with_mu(mu)

--- a/maybraid/sdf/common/src/noisy/unit_ball.rs
+++ b/maybraid/sdf/common/src/noisy/unit_ball.rs
@@ -1,0 +1,20 @@
+//! Suggested noise preset for unit-scale / playground noisy balls ([RFC-183 §3.1.2.2](https://github.com/ramate-io/maybraid/tree/main/rfc/rfc-000-000-183-chico-vegetation/03-01-stalk-and-ball-stick-trees/02-ball-components/02-noisy-ball/README.md)).
+
+use procedural_common::{NoiseParams, NoiseType};
+
+/// Zero-sized marker: [`From`] / [`Into`] yields a Perlin preset suited to typical unit spheres
+/// (same numeric recipe as [`super::unit_cylinder::UnitCylinderNoiseParams`]: amplitude `0.05`, frequency `5.0`, single octave).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct UnitBallNoiseParams;
+
+impl From<UnitBallNoiseParams> for NoiseParams {
+	fn from(_: UnitBallNoiseParams) -> Self {
+		Self {
+			amplitude: 0.05,
+			frequency: 5.0,
+			octaves: 1,
+			noise_type: NoiseType::Perlin,
+			..Default::default()
+		}
+	}
+}

--- a/util/chunk/src/cascade.rs
+++ b/util/chunk/src/cascade.rs
@@ -44,6 +44,7 @@ impl Ring {
 								z as f32 * self.size,
 							),
 						size: self.size,
+						extent: None,
 						res_2: self.res_2,
 						omit: None,
 					});
@@ -86,6 +87,10 @@ pub struct CascadeChunk {
 	pub world: u32,
 	pub origin: Vec3,
 	pub size: f32,
+	/// When `Some`, axis-aligned box from [`Self::origin`] with edge lengths `extent` (X, Y, Z).
+	/// [`Self::size`] should be `extent.x.max(extent.y).max(extent.z)` for ordering / caches.
+	/// When `None`, a cube with edge length [`Self::size`].
+	pub extent: Option<Vec3>,
 	pub res_2: u8,
 	pub omit: Option<Aabb3d>,
 }
@@ -95,12 +100,24 @@ impl Hash for CascadeChunk {
 		self.origin.x.to_bits().hash(state);
 		self.origin.y.to_bits().hash(state);
 		self.origin.z.to_bits().hash(state);
-		self.size.to_bits().hash(state);
+		let e = self.extent_vec();
+		e.x.to_bits().hash(state);
+		e.y.to_bits().hash(state);
+		e.z.to_bits().hash(state);
 		self.res_2.hash(state);
 	}
 }
 
 impl CascadeChunk {
+	/// Edge lengths (X, Y, Z) of this chunk’s axis-aligned sampling box.
+	#[inline]
+	pub fn extent_vec(&self) -> Vec3 {
+		match self.extent {
+			Some(e) => e,
+			None => Vec3::splat(self.size),
+		}
+	}
+
 	pub fn contains_point(&self, point: Vec3) -> bool {
 		if let Some(omit) = self.omit {
 			if omit.closest_point(point) == point.into() {
@@ -108,12 +125,13 @@ impl CascadeChunk {
 			}
 		}
 
+		let e = self.extent_vec();
 		point.x >= self.origin.x
-			&& point.x <= self.origin.x + self.size
+			&& point.x <= self.origin.x + e.x
 			&& point.y >= self.origin.y
-			&& point.y <= self.origin.y + self.size
+			&& point.y <= self.origin.y + e.y
 			&& point.z >= self.origin.z
-			&& point.z <= self.origin.z + self.size
+			&& point.z <= self.origin.z + e.z
 	}
 
 	pub fn column_contains_point(&self, point: Vec3) -> bool {
@@ -123,10 +141,11 @@ impl CascadeChunk {
 			}
 		}
 
+		let e = self.extent_vec();
 		point.x >= self.origin.x
-			&& point.x <= self.origin.x + self.size
+			&& point.x <= self.origin.x + e.x
 			&& point.z >= self.origin.z
-			&& point.z <= self.origin.z + self.size
+			&& point.z <= self.origin.z + e.z
 	}
 
 	pub fn resolution(&self) -> usize {
@@ -135,24 +154,62 @@ impl CascadeChunk {
 
 	/// Creates a chunk with a bottom left corner at the origin and a size of 1.0.
 	pub fn unit_chunk() -> Self {
-		Self { world: 0, origin: Vec3::ZERO, size: 1.0, res_2: 0, omit: None }
+		Self { world: 0, origin: Vec3::ZERO, size: 1.0, extent: None, res_2: 0, omit: None }
 	}
 
 	/// Creates a chunk with the center at the origin and diameters of 1.0.
 	pub fn unit_center_chunk() -> Self {
-		Self { world: 0, origin: Vec3::new(-0.5, 0.0, -0.5), size: 1.0, res_2: 0, omit: None }
+		Self {
+			world: 0,
+			origin: Vec3::new(-0.5, 0.0, -0.5),
+			size: 1.0,
+			extent: None,
+			res_2: 0,
+			omit: None,
+		}
 	}
 
 	/// Creates a chunk with the center at the origin and a size of 1.0.
 	pub fn unit_3d_center_chunk() -> Self {
-		Self { world: 0, origin: Vec3::new(-0.5, -0.5, -0.5), size: 1.0, res_2: 0, omit: None }
+		Self {
+			world: 0,
+			origin: Vec3::new(-0.5, -0.5, -0.5),
+			size: 1.0,
+			extent: None,
+			res_2: 0,
+			omit: None,
+		}
+	}
+
+	/// [`unit_center_chunk`] with anisotropic padding: **X/Z** by `μ_xz`, **Y** by `μ_y` (keeps the
+	/// nominal segment near **y ∈ [0, 1]** with only small cap padding when `μ_y` is small).
+	pub fn unit_center_chunk_with_mu_xz_y(mu_xz: f32, mu_y: f32) -> Self {
+		let ex = 1.0 + 2.0 * mu_xz;
+		let ey = 1.0 + 2.0 * mu_y;
+		let ez = 1.0 + 2.0 * mu_xz;
+		let extent = Vec3::new(ex, ey, ez);
+		Self {
+			world: 0,
+			origin: Vec3::new(-0.5 - mu_xz, -mu_y, -0.5 - mu_xz),
+			size: ex.max(ey).max(ez),
+			extent: Some(extent),
+			res_2: 0,
+			omit: None,
+		}
 	}
 
 	/// Updates a chunk with some Mu for the geometry that goes slightly beyond the unit.
 	pub fn with_mu(self, mu: f32) -> Self {
 		let origin = self.origin + Vec3::new(-mu, -mu, -mu);
 		let size = self.size + 2.0 * mu;
-		Self { world: self.world, origin, size, res_2: self.res_2, omit: self.omit }
+		Self {
+			world: self.world,
+			origin,
+			size,
+			extent: None,
+			res_2: self.res_2,
+			omit: self.omit,
+		}
 	}
 
 	pub fn with_res_2(mut self, res_2: u8) -> Self {
@@ -263,6 +320,7 @@ impl<R: ResolutionMap> Cascade<R> {
 			world: 0,
 			origin,
 			size: self.min_size,
+			extent: None,
 			res_2: self.resolution_map.ring_to_power_of_2(0),
 			omit: None,
 		}
@@ -345,6 +403,7 @@ impl<R: ResolutionMap> Cascade<R> {
 						world: 0,
 						origin: chunk_origin,
 						size: self.grid_chunk_size(),
+						extent: None,
 						res_2: self.resolution_map.ring_to_power_of_2(self.number_of_rings),
 						omit,
 					};
@@ -460,6 +519,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 0.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -467,6 +527,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 0.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -474,6 +535,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 0.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -481,6 +543,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 1.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -488,6 +551,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 1.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			}, // center
@@ -495,6 +559,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 1.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -502,6 +567,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 2.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -509,6 +575,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 2.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -516,6 +583,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 2.0 * size, 0.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -524,6 +592,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 0.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -531,6 +600,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 0.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -538,6 +608,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 0.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -545,6 +616,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 1.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -552,6 +624,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 1.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -559,6 +632,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 1.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -566,6 +640,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 2.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -573,6 +648,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 2.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -580,6 +656,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 2.0 * size, 1.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -588,6 +665,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 0.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -595,6 +673,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 0.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -602,6 +681,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 0.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -609,6 +689,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 1.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -616,6 +697,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 1.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -623,6 +705,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 1.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -630,6 +713,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(0.0 * size, 2.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -637,6 +721,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(1.0 * size, 2.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -644,6 +729,7 @@ mod tests {
 				world: 0,
 				origin: lower_left_bottom + Vec3::new(2.0 * size, 2.0 * size, 2.0 * size),
 				size,
+				extent: None,
 				res_2,
 				omit: None,
 			},
@@ -662,6 +748,7 @@ mod tests {
 			world: 0,
 			origin: lower_left_bottom + Vec3::new(1.0 * size, 1.0 * size, 1.0 * size),
 			size,
+			extent: None,
 			res_2,
 			omit: None,
 		};
@@ -739,6 +826,7 @@ mod tests {
 			world: 0,
 			origin: Vec3::new(0.0, 0.0, 0.0),
 			size: 1.0,
+			extent: None,
 			res_2: 0,
 			omit: None,
 		};
@@ -794,6 +882,7 @@ mod tests {
 			world: 0,
 			origin: Vec3::new(0.0, 0.0, 0.0),
 			size: 2.5,
+			extent: None,
 			res_2: 1,
 			omit: None,
 		};
@@ -841,6 +930,7 @@ mod tests {
 			world: 0,
 			origin: Vec3::new(0.0, 0.0, 0.0),
 			size: 0.5,
+			extent: None,
 			res_2: 2,
 			omit: None,
 		};

--- a/util/render-item/src/sdf/cpu_shot.rs
+++ b/util/render-item/src/sdf/cpu_shot.rs
@@ -5,15 +5,15 @@ use chunk::cascade::CascadeChunk;
 use sdf::{Sign, Sdf};
 use std::sync::Arc;
 use rayon::prelude::*;
-use marching_cubes::{get_cube_index, interpolate_vertex, TRIANGULATIONS};
+use marching_cubes::{get_cube_index, interpolate_vertex_cell, TRIANGULATIONS};
 use crate::mesh::MeshBuilder;
 use crate::NormalizeChunk;
 pub trait CpuShotSdf: Sdf + Clone {
 	fn cpu_chunk_mesh(&self, cascade_chunk: &CascadeChunk) -> Option<Mesh> {
         // ---------- grid setup ---------------------------------------------------
-		let chunk_size = cascade_chunk.size;
+		let extent = cascade_chunk.extent_vec();
 		let res = cascade_chunk.resolution();
-		let cube_size = chunk_size / res as f32;
+		let cube_cell = extent / res as f32;
 		let chunk_origin = cascade_chunk.origin;
 
 		// ---------- grid setup ---------------------------------------------------
@@ -39,12 +39,12 @@ pub trait CpuShotSdf: Sdf + Clone {
 		let z_slices: Vec<_> = (0..nz)
 			.into_par_iter()
 			.map(|z| {
-				let wz = chunk_origin.z + z as f32 * cube_size;
+				let wz = chunk_origin.z + z as f32 * cube_cell.z;
 				let mut slice = vec![0.0f32; nx * ny];
 
 				// For each x position, compute intervals and sample sparsely
 				for x in 0..nx {
-					let wx = chunk_origin.x + x as f32 * cube_size;
+					let wx = chunk_origin.x + x as f32 * cube_cell.x;
 					// Get intervals for this (x, z) position
 					let intervals = sdf_clone.sign_uniform_on_y(wx, wz);
 
@@ -63,11 +63,11 @@ pub trait CpuShotSdf: Sdf + Clone {
 						// Convert world Y coordinates to grid indices
 						// Clamp to chunk bounds
 						let y_start_world = y_min_world.max(chunk_origin.y);
-						let y_end_world = y_max_world.min(chunk_origin.y + chunk_size);
+						let y_end_world = y_max_world.min(chunk_origin.y + extent.y);
 
 						let y_start =
-							((y_start_world - chunk_origin.y) / cube_size).floor() as usize;
-						let y_end = ((y_end_world - chunk_origin.y) / cube_size)
+							((y_start_world - chunk_origin.y) / cube_cell.y).floor() as usize;
+						let y_end = ((y_end_world - chunk_origin.y) / cube_cell.y)
 							.ceil()
 							.min(ny as f32) as usize;
 
@@ -86,7 +86,7 @@ pub trait CpuShotSdf: Sdf + Clone {
 								Sign::Top | Sign::Bottom => {
 									// Unknown/undefined sign - need to sample normally
 									for yi in y_begin..y_finish {
-										let wy = chunk_origin.y + yi as f32 * cube_size;
+										let wy = chunk_origin.y + yi as f32 * cube_cell.y;
 										let distance = sdf_clone.distance(Vec3::new(wx, wy, wz));
 										slice[yi * nx + x] = distance;
 									}
@@ -100,7 +100,7 @@ pub trait CpuShotSdf: Sdf + Clone {
 									// If interval is small, just sample everything
 									if interval_size <= TRANSITION_VOXELS * 2 {
 										for yi in y_begin..y_finish {
-											let wy = chunk_origin.y + yi as f32 * cube_size;
+											let wy = chunk_origin.y + yi as f32 * cube_cell.y;
 											let distance = sdf_clone.distance(Vec3::new(wx, wy, wz));
 											slice[yi * nx + x] = distance;
 										}
@@ -108,7 +108,7 @@ pub trait CpuShotSdf: Sdf + Clone {
 										// Sample at START boundary (where surface transition might be)
 										let start_sample_end = (y_begin + TRANSITION_VOXELS).min(y_finish);
 										for yi in y_begin..start_sample_end {
-											let wy = chunk_origin.y + yi as f32 * cube_size;
+											let wy = chunk_origin.y + yi as f32 * cube_cell.y;
 											let distance = sdf_clone.distance(Vec3::new(wx, wy, wz));
 											slice[yi * nx + x] = distance;
 										}
@@ -129,7 +129,7 @@ pub trait CpuShotSdf: Sdf + Clone {
 										
 										// Sample at END boundary (where next interval starts = surface transition)
 										for yi in fill_end.max(fill_start)..y_finish {
-											let wy = chunk_origin.y + yi as f32 * cube_size;
+											let wy = chunk_origin.y + yi as f32 * cube_cell.y;
 											let distance = sdf_clone.distance(Vec3::new(wx, wy, wz));
 											slice[yi * nx + x] = distance;
 										}
@@ -157,7 +157,7 @@ pub trait CpuShotSdf: Sdf + Clone {
 					if y_current < ny {
 						// Treat remaining as Top (unknown) and sample
 						for yi in y_current..ny {
-							let wy = chunk_origin.y + yi as f32 * cube_size;
+							let wy = chunk_origin.y + yi as f32 * cube_cell.y;
 							let distance = sdf_clone.distance(Vec3::new(wx, wy, wz));
 							slice[yi * nx + x] = distance;
 						}
@@ -209,8 +209,11 @@ pub trait CpuShotSdf: Sdf + Clone {
 			.into_par_iter()
 			.filter_map(|(x, y, z)| {
 				// Local-space cube origin (all dimensions relative to chunk origin)
-				let cube_pos_local =
-					Vec3::new(x as f32 * cube_size, y as f32 * cube_size, z as f32 * cube_size);
+				let cube_pos_local = Vec3::new(
+					x as f32 * cube_cell.x,
+					y as f32 * cube_cell.y,
+					z as f32 * cube_cell.z,
+				);
 				
 				
 				// Corner scalar values (standard MC corner ordering assumed by your helpers)
@@ -258,7 +261,7 @@ pub trait CpuShotSdf: Sdf + Clone {
 							return v;
 						}
 						let pos_local =
-							interpolate_vertex(edge, cube_pos_local, cube_size, corners);
+							interpolate_vertex_cell(edge, cube_pos_local, cube_cell, corners);
 						let v_index = cube_vertices.len() as u32;
 						cube_vertices.push([pos_local.x, pos_local.y, pos_local.z]);
 						edge_vert[edge] = Some(v_index);
@@ -304,13 +307,16 @@ pub trait CpuShotSdf: Sdf + Clone {
 		// Normals: compute from voxel grid using finite differences
 		// Vertices are in local space (relative to chunk_origin)
 		let grid_slice: &[f32] = &grid;
+		let hx = cube_cell.x.max(1e-20);
+		let hy = cube_cell.y.max(1e-20);
+		let hz = cube_cell.z.max(1e-20);
 		let normals: Vec<[f32; 3]> = vertices
 			.par_iter()
 			.map(|v| {
 				// Convert vertex local position to grid coordinates
-				let gx = (v[0] / cube_size).clamp(0.0, (nx - 1) as f32);
-				let gy = (v[1] / cube_size).clamp(0.0, (ny - 1) as f32);
-				let gz = (v[2] / cube_size).clamp(0.0, (nz - 1) as f32);
+				let gx = (v[0] / hx).clamp(0.0, (nx - 1) as f32);
+				let gy = (v[1] / hy).clamp(0.0, (ny - 1) as f32);
+				let gz = (v[2] / hz).clamp(0.0, (nz - 1) as f32);
 
 				// Get integer grid indices (truncate for now, could interpolate)
 				let ix = gx as usize;
@@ -318,55 +324,46 @@ pub trait CpuShotSdf: Sdf + Clone {
 				let iz = gz as usize;
 
 				// Compute finite differences using central differences where possible
-				// ∂f/∂x = (f(x+1) - f(x-1)) / (2 * cube_size)
 				let dx = if ix > 0 && ix < nx - 1 {
 					let f_xp1 = grid_slice[idx(ix + 1, iy, iz)];
 					let f_xm1 = grid_slice[idx(ix - 1, iy, iz)];
-					(f_xp1 - f_xm1) / (2.0 * cube_size)
+					(f_xp1 - f_xm1) / (2.0 * hx)
 				} else if ix < nx - 1 {
-					// Forward difference at left boundary
 					let f_xp1 = grid_slice[idx(ix + 1, iy, iz)];
 					let f_x = grid_slice[idx(ix, iy, iz)];
-					(f_xp1 - f_x) / cube_size
+					(f_xp1 - f_x) / hx
 				} else {
-					// Backward difference at right boundary
 					let f_x = grid_slice[idx(ix, iy, iz)];
 					let f_xm1 = grid_slice[idx(ix - 1, iy, iz)];
-					(f_x - f_xm1) / cube_size
+					(f_x - f_xm1) / hx
 				};
 
-				// ∂f/∂y = (f(y+1) - f(y-1)) / (2 * cube_size)
 				let dy = if iy > 0 && iy < ny - 1 {
 					let f_yp1 = grid_slice[idx(ix, iy + 1, iz)];
 					let f_ym1 = grid_slice[idx(ix, iy - 1, iz)];
-					(f_yp1 - f_ym1) / (2.0 * cube_size)
+					(f_yp1 - f_ym1) / (2.0 * hy)
 				} else if iy < ny - 1 {
-					// Forward difference at bottom boundary
 					let f_yp1 = grid_slice[idx(ix, iy + 1, iz)];
 					let f_y = grid_slice[idx(ix, iy, iz)];
-					(f_yp1 - f_y) / cube_size
+					(f_yp1 - f_y) / hy
 				} else {
-					// Backward difference at top boundary
 					let f_y = grid_slice[idx(ix, iy, iz)];
 					let f_ym1 = grid_slice[idx(ix, iy - 1, iz)];
-					(f_y - f_ym1) / cube_size
+					(f_y - f_ym1) / hy
 				};
 
-				// ∂f/∂z = (f(z+1) - f(z-1)) / (2 * cube_size)
 				let dz = if iz > 0 && iz < nz - 1 {
 					let f_zp1 = grid_slice[idx(ix, iy, iz + 1)];
 					let f_zm1 = grid_slice[idx(ix, iy, iz - 1)];
-					(f_zp1 - f_zm1) / (2.0 * cube_size)
+					(f_zp1 - f_zm1) / (2.0 * hz)
 				} else if iz < nz - 1 {
-					// Forward difference at front boundary
 					let f_zp1 = grid_slice[idx(ix, iy, iz + 1)];
 					let f_z = grid_slice[idx(ix, iy, iz)];
-					(f_zp1 - f_z) / cube_size
+					(f_zp1 - f_z) / hz
 				} else {
-					// Backward difference at back boundary
 					let f_z = grid_slice[idx(ix, iy, iz)];
 					let f_zm1 = grid_slice[idx(ix, iy, iz - 1)];
-					(f_z - f_zm1) / cube_size
+					(f_z - f_zm1) / hz
 				};
 
 				// Normalize the gradient to get the normal
@@ -385,8 +382,10 @@ pub trait CpuShotSdf: Sdf + Clone {
 
 		// Simple tiled UVs (local X/Z across the chunk)
 		let start_time = std::time::Instant::now();
+		let u_scale = extent.x.max(1e-20);
+		let v_scale = extent.z.max(1e-20);
 		let uvs: Vec<[f32; 2]> =
-			vertices.par_iter().map(|v| [v[0] / chunk_size, v[2] / chunk_size]).collect();
+			vertices.par_iter().map(|v| [v[0] / u_scale, v[2] / v_scale]).collect();
 		let end_time = std::time::Instant::now();
 		let duration = end_time.duration_since(start_time);
 		log::debug!("UVs time: {:?}", duration);

--- a/util/render-item/src/sdf/cpu_shot/marching_cubes.rs
+++ b/util/render-item/src/sdf/cpu_shot/marching_cubes.rs
@@ -91,6 +91,42 @@ pub fn interpolate_vertex(
 	cube_origin + pos_local * cube_size
 }
 
+/// Like [`interpolate_vertex`], but with an **axis-aligned** cell size (non-cubic voxels).
+#[inline]
+pub fn interpolate_vertex_cell(
+	edge: usize,
+	cube_origin: Vec3,
+	cube_cell: Vec3,
+	corner_values: [f32; 8],
+) -> Vec3 {
+	const CUBE_CORNERS: [Vec3; 8] = [
+		Vec3::new(0.0, 0.0, 0.0),
+		Vec3::new(1.0, 0.0, 0.0),
+		Vec3::new(1.0, 0.0, 1.0),
+		Vec3::new(0.0, 0.0, 1.0),
+		Vec3::new(0.0, 1.0, 0.0),
+		Vec3::new(1.0, 1.0, 0.0),
+		Vec3::new(1.0, 1.0, 1.0),
+		Vec3::new(0.0, 1.0, 1.0),
+	];
+
+	let (a, b) = EDGE_VERTEX_INDICES[edge];
+	let v1 = CUBE_CORNERS[a];
+	let v2 = CUBE_CORNERS[b];
+	let val1 = corner_values[a];
+	let val2 = corner_values[b];
+
+	if (val1 - val2).abs() < 1e-6 {
+		return cube_origin + (v1 + v2) * 0.5 * cube_cell;
+	}
+
+	let t = (-val1) / (val2 - val1);
+	let t = t.clamp(0.0, 1.0);
+
+	let pos_local = v1 + (v2 - v1) * t;
+	cube_origin + pos_local * cube_cell
+}
+
 // Full triangulation table - 256 entries, one for each possible cube configuration
 // Each entry is a list of edge indices forming triangles, terminated by -1
 // Based on: https://gist.github.com/dwilliamson/c041e3454a713e58baf6e4f8e5fffecd


### PR DESCRIPTION
# Summary
Implements crook cylinder. 

Standard: 

```shell
cargo run -p sdf-common-playground  --release -- render crook-cylinder --bend-x 0.12 --bend-z 0.08
```

Noisy: 

```shell
cargo run -p sdf-common-playground  --release -- render noisy-crook-cylinder --suggested --bend-x 0.12 --bend-z 0.08 
```