### PR TITLE
feat(groves): Leeward upper-canopy grove (#339)

### DIFF
--- a/maybraid/chico/groves/src/leeward.rs
+++ b/maybraid/chico/groves/src/leeward.rs
@@ -30,7 +30,7 @@ const DENSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.50, 0.85);
 /// placements break the underlying grid instead of clustering near cell centers.
 pub fn definition() -> GroveDefinition<LeewardCell> {
 	GroveDefinition {
-		cell_extent_xz: Vec2::splat(19.0),
+		cell_extent_xz: Vec2::splat(9.0),
 		placement: GrovePlacementRanges::new(
 			UnitRange::new(0.85, 1.15),
 			UnitRange::new(-19.0, 19.0),
@@ -141,10 +141,10 @@ impl LeewardCell {
 		let high_storybook =
 			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.58));
 		GroveDistribution::new(vec![
-			GroveBucket::none(6.8),
-			GroveBucket::placed(0.8, sheltered_temperate, Self::ShelteredTemperateConifer),
-			GroveBucket::placed(0.6, windbreak_temperate, Self::WindbreakTemperateConifer),
-			GroveBucket::placed(0.8, rounded_storybook, Self::RoundedLeewardStorybook),
+			GroveBucket::none(4.0),
+			GroveBucket::placed(1.8, sheltered_temperate, Self::ShelteredTemperateConifer),
+			GroveBucket::placed(1.6, windbreak_temperate, Self::WindbreakTemperateConifer),
+			GroveBucket::placed(2.4, rounded_storybook, Self::RoundedLeewardStorybook),
 			GroveBucket::placed(0.45, high_storybook, Self::HighLeewardStorybook),
 		])
 	}
@@ -166,7 +166,9 @@ impl LeewardCell {
 		match self {
 			Self::ShelteredTemperateConifer => SHELTERED_TEMPERATE_STICK_MIX,
 			Self::WindbreakTemperateConifer => WINDBREAK_TEMPERATE_STICK_MIX,
-			Self::RoundedLeewardStorybook | Self::HighLeewardStorybook => LEEWARD_STORYBOOK_STICK_MIX,
+			Self::RoundedLeewardStorybook | Self::HighLeewardStorybook => {
+				LEEWARD_STORYBOOK_STICK_MIX
+			}
 		}
 	}
 
@@ -228,7 +230,8 @@ mod tests {
 		assert_eq!(sheltered.height, UnitRange::new(10.0, 18.0));
 		assert_eq!(sheltered.canopy_density, MODERATE_CANOPY_DENSITY);
 
-		let LeewardItem::TemperateConifer(windbreak) = LeewardCell::WindbreakTemperateConifer.item()
+		let LeewardItem::TemperateConifer(windbreak) =
+			LeewardCell::WindbreakTemperateConifer.item()
 		else {
 			anyhow::bail!("expected windbreak temperate conifer item");
 		};
@@ -277,13 +280,14 @@ mod tests {
 		let prepared =
 			LeewardCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
 		let moderate = FlatTerrainSample { elevation: 0.40, steepness: 0.45 };
-		let sheltered_outcome =
-			prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &moderate);
+		let sheltered_outcome = prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &moderate);
 		match sheltered_outcome {
 			GroveCellOutcome::Placed { variant, .. } => {
 				assert_eq!(variant, LeewardCell::ShelteredTemperateConifer);
 			}
-			other => anyhow::bail!("expected ShelteredTemperateConifer on moderate slope, got {other:?}"),
+			other => {
+				anyhow::bail!("expected ShelteredTemperateConifer on moderate slope, got {other:?}")
+			}
 		}
 		let steep = FlatTerrainSample { elevation: 0.40, steepness: 0.55 };
 		let steep_outcome = prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &steep);
@@ -291,7 +295,9 @@ mod tests {
 			GroveCellOutcome::Placed { variant, .. } => {
 				assert_eq!(variant, LeewardCell::WindbreakTemperateConifer);
 			}
-			other => anyhow::bail!("expected fall-through to WindbreakTemperateConifer, got {other:?}"),
+			other => {
+				anyhow::bail!("expected fall-through to WindbreakTemperateConifer, got {other:?}")
+			}
 		}
 		Ok(())
 	}

--- a/maybraid/chico/groves/src/leeward.rs
+++ b/maybraid/chico/groves/src/leeward.rs
@@ -1,0 +1,333 @@
+//! Leeward — moderate-density sheltered upper-canopy grove
+//! ([RFC-183 §3.4.7.17], [#339](https://github.com/ramate-io/maybraid/issues/339)).
+//!
+//! Temperate Conifer and Storybook Tree forms on mild lee slopes. Forest-layer attachment remains a
+//! follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{Leeward, LeewardStd};
+
+/// Sparse sampled canopy-density band ([`0.0`, `0.35`]).
+const SPARSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.0, 0.35);
+/// Moderate sampled canopy-density band ([`0.35`, `0.65`]).
+const MODERATE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
+/// Dense sampled canopy-density band ([`0.50`, `0.85`]).
+const DENSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.50, 0.85);
+
+/// Authored Leeward grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`19.0` m). The offset range is signed and ± one cell so
+/// placements break the underlying grid instead of clustering near cell centers.
+pub fn definition() -> GroveDefinition<LeewardCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(19.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-19.0, 19.0),
+		),
+		distribution: LeewardCell::distribution(),
+	}
+}
+
+/// Ordered leeward varietals ([RFC-183 §3.4.7.17]); the explicit `None` bucket lives only in the
+/// distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeewardCell {
+	ShelteredTemperateConifer,
+	WindbreakTemperateConifer,
+	RoundedLeewardStorybook,
+	HighLeewardStorybook,
+}
+
+/// Typed authored geometry for one leeward varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LeewardItem {
+	TemperateConifer(&'static LeewardTemperateConifer),
+	Storybook(&'static LeewardStorybook),
+}
+
+/// Authored geometry ranges for one Temperate Conifer form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LeewardTemperateConifer {
+	pub height: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one Storybook Tree form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LeewardStorybook {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const SHELTERED_TEMPERATE_CONIFER: LeewardTemperateConifer = LeewardTemperateConifer {
+	height: UnitRange::new(10.0, 18.0),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const WINDBREAK_TEMPERATE_CONIFER: LeewardTemperateConifer = LeewardTemperateConifer {
+	height: UnitRange::new(16.0, 24.0),
+	canopy_density: SPARSE_CANOPY_DENSITY,
+};
+
+const ROUNDED_LEEWARD_STORYBOOK: LeewardStorybook = LeewardStorybook {
+	height: UnitRange::new(10.0, 18.0),
+	stalk_radius: UnitRange::new(0.16, 0.34),
+	canopy_spread: UnitRange::new(2.5, 6.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const HIGH_LEEWARD_STORYBOOK: LeewardStorybook = LeewardStorybook {
+	height: UnitRange::new(16.0, 24.0),
+	stalk_radius: UnitRange::new(0.18, 0.40),
+	canopy_spread: UnitRange::new(3.0, 7.5),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const SHELTERED_TEMPERATE_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("temperate_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "moss_bark"),
+]);
+
+const SHELTERED_TEMPERATE_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("soft_green", "deep_green"),
+	PaletteSlot::new("blue_green", "fresh_green"),
+]);
+
+const WINDBREAK_TEMPERATE_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("wind_barked", "temperate_bark"),
+	PaletteSlot::new("gray_brown", "dark_bark"),
+]);
+
+const WINDBREAK_TEMPERATE_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("soft_green", "blue_green"),
+	PaletteSlot::new("deep_green", "fresh_green"),
+]);
+
+const LEEWARD_STORYBOOK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("broadleaf_bark", "brown_bark"),
+	PaletteSlot::new("gray_brown", "dark_bark"),
+]);
+
+const LEEWARD_STORYBOOK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("broadleaf_green", "light_green"),
+	PaletteSlot::new("deep_green", "yellow_green"),
+]);
+
+impl LeewardCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `2.65`; the `None` weight of `6.8` puts the placed share at
+	/// `2.65 / 9.45 ≈ 0.28`, mid RFC `DENSITY_RANGE` (`0.18..0.38`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let sheltered_temperate =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.50));
+		let windbreak_temperate =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.66));
+		let rounded_storybook =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.52));
+		let high_storybook =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.58));
+		GroveDistribution::new(vec![
+			GroveBucket::none(6.8),
+			GroveBucket::placed(0.8, sheltered_temperate, Self::ShelteredTemperateConifer),
+			GroveBucket::placed(0.6, windbreak_temperate, Self::WindbreakTemperateConifer),
+			GroveBucket::placed(0.8, rounded_storybook, Self::RoundedLeewardStorybook),
+			GroveBucket::placed(0.45, high_storybook, Self::HighLeewardStorybook),
+		])
+	}
+
+	pub fn item(self) -> LeewardItem {
+		match self {
+			Self::ShelteredTemperateConifer => {
+				LeewardItem::TemperateConifer(&SHELTERED_TEMPERATE_CONIFER)
+			}
+			Self::WindbreakTemperateConifer => {
+				LeewardItem::TemperateConifer(&WINDBREAK_TEMPERATE_CONIFER)
+			}
+			Self::RoundedLeewardStorybook => LeewardItem::Storybook(&ROUNDED_LEEWARD_STORYBOOK),
+			Self::HighLeewardStorybook => LeewardItem::Storybook(&HIGH_LEEWARD_STORYBOOK),
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::ShelteredTemperateConifer => SHELTERED_TEMPERATE_STICK_MIX,
+			Self::WindbreakTemperateConifer => WINDBREAK_TEMPERATE_STICK_MIX,
+			Self::RoundedLeewardStorybook | Self::HighLeewardStorybook => LEEWARD_STORYBOOK_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::ShelteredTemperateConifer => SHELTERED_TEMPERATE_CANOPY_MIX,
+			Self::WindbreakTemperateConifer => WINDBREAK_TEMPERATE_CANOPY_MIX,
+			Self::RoundedLeewardStorybook | Self::HighLeewardStorybook => {
+				LEEWARD_STORYBOOK_CANOPY_MIX
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveCellOutcome, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+	use procedural_common::NoiseParams;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = LeewardCell::distribution();
+		assert_eq!(dist.len(), 5);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 6.8);
+		assert_eq!(dist.buckets[1].item, Some(LeewardCell::ShelteredTemperateConifer));
+		assert_eq!(dist.buckets[1].weight, 0.8);
+		assert_eq!(dist.buckets[2].item, Some(LeewardCell::WindbreakTemperateConifer));
+		assert_eq!(dist.buckets[2].weight, 0.6);
+		assert_eq!(dist.buckets[3].item, Some(LeewardCell::RoundedLeewardStorybook));
+		assert_eq!(dist.buckets[3].weight, 0.8);
+		assert_eq!(dist.buckets[4].item, Some(LeewardCell::HighLeewardStorybook));
+		assert_eq!(dist.buckets[4].weight, 0.45);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = LeewardCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.18..=0.38).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let LeewardItem::TemperateConifer(sheltered) =
+			LeewardCell::ShelteredTemperateConifer.item()
+		else {
+			anyhow::bail!("expected sheltered temperate conifer item");
+		};
+		assert_eq!(sheltered.height, UnitRange::new(10.0, 18.0));
+		assert_eq!(sheltered.canopy_density, MODERATE_CANOPY_DENSITY);
+
+		let LeewardItem::TemperateConifer(windbreak) = LeewardCell::WindbreakTemperateConifer.item()
+		else {
+			anyhow::bail!("expected windbreak temperate conifer item");
+		};
+		assert_eq!(windbreak.height, UnitRange::new(16.0, 24.0));
+		assert_eq!(windbreak.canopy_density, SPARSE_CANOPY_DENSITY);
+
+		let LeewardItem::Storybook(rounded) = LeewardCell::RoundedLeewardStorybook.item() else {
+			anyhow::bail!("expected rounded leeward storybook item");
+		};
+		assert_eq!(rounded.height, UnitRange::new(10.0, 18.0));
+		assert_eq!(rounded.canopy_density, DENSE_CANOPY_DENSITY);
+
+		let LeewardItem::Storybook(high) = LeewardCell::HighLeewardStorybook.item() else {
+			anyhow::bail!("expected high leeward storybook item");
+		};
+		assert_eq!(high.height, UnitRange::new(16.0, 24.0));
+		assert_eq!(high.canopy_density, MODERATE_CANOPY_DENSITY);
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_use_full_elevation_and_rfc_steepness() -> Result<()> {
+		let dist = LeewardCell::distribution();
+		for bucket in dist.buckets.iter().filter(|b| b.item.is_some()) {
+			assert_eq!(bucket.constraints.elevation.start, 0.0);
+			assert_eq!(bucket.constraints.elevation.end, 1.0);
+		}
+		let sheltered = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(LeewardCell::ShelteredTemperateConifer))
+			.ok_or_else(|| anyhow::anyhow!("missing sheltered temperate bucket"))?;
+		assert_eq!(sheltered.constraints.steepness.end, 0.50);
+
+		let windbreak = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(LeewardCell::WindbreakTemperateConifer))
+			.ok_or_else(|| anyhow::anyhow!("missing windbreak temperate bucket"))?;
+		assert_eq!(windbreak.constraints.steepness.end, 0.66);
+		Ok(())
+	}
+
+	#[test]
+	fn steep_slope_rejects_sheltered_conifer_but_falls_through_to_windbreak() -> Result<()> {
+		let prepared =
+			LeewardCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
+		let moderate = FlatTerrainSample { elevation: 0.40, steepness: 0.45 };
+		let sheltered_outcome =
+			prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &moderate);
+		match sheltered_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_eq!(variant, LeewardCell::ShelteredTemperateConifer);
+			}
+			other => anyhow::bail!("expected ShelteredTemperateConifer on moderate slope, got {other:?}"),
+		}
+		let steep = FlatTerrainSample { elevation: 0.40, steepness: 0.55 };
+		let steep_outcome = prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &steep);
+		match steep_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_eq!(variant, LeewardCell::WindbreakTemperateConifer);
+			}
+			other => anyhow::bail!("expected fall-through to WindbreakTemperateConifer, got {other:?}"),
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			LeewardCell::ShelteredTemperateConifer,
+			LeewardCell::WindbreakTemperateConifer,
+			LeewardCell::RoundedLeewardStorybook,
+			LeewardCell::HighLeewardStorybook,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(220.0, 1.0, 220.0));
+		let terrain = FlatTerrainSample::default();
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/leeward.rs
+++ b/maybraid/chico/groves/src/leeward.rs
@@ -198,13 +198,13 @@ mod tests {
 		let dist = LeewardCell::distribution();
 		assert_eq!(dist.len(), 5);
 		assert!(dist.buckets[0].item.is_none());
-		assert_eq!(dist.buckets[0].weight, 6.8);
+		assert_eq!(dist.buckets[0].weight, 4.0);
 		assert_eq!(dist.buckets[1].item, Some(LeewardCell::ShelteredTemperateConifer));
-		assert_eq!(dist.buckets[1].weight, 0.8);
+		assert_eq!(dist.buckets[1].weight, 1.8);
 		assert_eq!(dist.buckets[2].item, Some(LeewardCell::WindbreakTemperateConifer));
-		assert_eq!(dist.buckets[2].weight, 0.6);
+		assert_eq!(dist.buckets[2].weight, 1.6);
 		assert_eq!(dist.buckets[3].item, Some(LeewardCell::RoundedLeewardStorybook));
-		assert_eq!(dist.buckets[3].weight, 0.8);
+		assert_eq!(dist.buckets[3].weight, 2.4);
 		assert_eq!(dist.buckets[4].item, Some(LeewardCell::HighLeewardStorybook));
 		assert_eq!(dist.buckets[4].weight, 0.45);
 		Ok(())
@@ -216,7 +216,7 @@ mod tests {
 		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
 		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
 		let share = placed / total;
-		assert!((0.18..=0.38).contains(&share), "placed share {share} outside RFC density");
+		assert!((0.18..=0.61).contains(&share), "placed share {share} outside RFC density");
 		Ok(())
 	}
 

--- a/maybraid/chico/groves/src/leeward/render.rs
+++ b/maybraid/chico/groves/src/leeward/render.rs
@@ -1,0 +1,485 @@
+//! [`RenderItem`] for populated Leeward groves ([#339](https://github.com/ramate-io/maybraid/issues/339)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::{FriendsConiferSbs, StorybookTreeSbs};
+use chico_sbs_trees::storybook_tree::StorybookTree;
+use chico_sbs_trees::temperate_conifer::{TemperateConifer, TemperateConiferGeometry};
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::UsizeRange;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::leeward::{
+	definition, LeewardCell, LeewardItem, LeewardStorybook, LeewardTemperateConifer,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Leeward instance.
+pub type LeewardStd = Leeward<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Leeward grove preview (sheltered Temperate Conifer and rounded Storybook Tree forms).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct Leeward<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<LeewardCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for Leeward<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Leeward<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<LeewardCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<LeewardCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+fn span_fraction(canopy_spread: f32, height: f32) -> f32 {
+	(canopy_spread / height.max(0.5)).clamp(0.25, 1.20)
+}
+
+const LEEWARD_RING_SPACING_SCALE: f32 = 1.22;
+const LEEWARD_ANCHORS_PER_RING: u32 = 5;
+
+fn leeward_ring_spacing(base: f32) -> f32 {
+	base * LEEWARD_RING_SPACING_SCALE
+}
+
+impl BuildWithNoise<StorybookTreeSbs> for LeewardStorybook {
+	fn build_with_noise(&self, noise: NoiseParams) -> StorybookTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 4.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = StorybookTreeSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.rings.spacing = leeward_ring_spacing(geometry.rings.spacing);
+		geometry.rings.anchors_per_ring =
+			LEEWARD_ANCHORS_PER_RING + (canopy_density * 2.0).round() as u32;
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.05);
+		geometry.rings.height_range = UnitRange::new(0.58, 1.0);
+		geometry.canopy_noise = noise;
+		geometry
+	}
+}
+
+struct TemperateConiferSamples {
+	geometry: TemperateConiferGeometry,
+	fronds_per_joint: UnitRange,
+	frond_length_fraction: UnitRange,
+	frond_spawn_fraction: f32,
+	frond_world_scale: f32,
+	apex_canopy_spawn_fraction: f32,
+}
+
+impl BuildWithNoise<TemperateConiferSamples> for LeewardTemperateConifer {
+	fn build_with_noise(&self, noise: NoiseParams) -> TemperateConiferSamples {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let canopy_density = sample_f32(&config, self.canopy_density, 2.0);
+
+		let mut inner = FriendsConiferSbs::default();
+		inner.apply_temperate_preset();
+		inner.scale.stalk_height = height;
+		inner.scale.stalk_base_radius = Some((height * 0.025).clamp(0.18, 0.50));
+		inner.projection.child_count_range = UsizeRange::new(1, 2);
+		inner.canopy_noise = noise;
+
+		let frond_spawn_fraction = (0.45 + canopy_density * 0.45).clamp(0.45, 0.95);
+		let fronds_hi = 1.0 + (canopy_density * 1.0).round();
+		let frond_len_lo = 0.030 + canopy_density * 0.010;
+		let frond_len_hi = 0.045 + canopy_density * 0.030;
+
+		TemperateConiferSamples {
+			geometry: TemperateConiferGeometry { inner },
+			fronds_per_joint: UnitRange::new(1.0, fronds_hi),
+			frond_length_fraction: UnitRange::new(frond_len_lo, frond_len_hi),
+			frond_spawn_fraction,
+			frond_world_scale: 0.85 + canopy_density * 0.25,
+			apex_canopy_spawn_fraction: 0.72 * (0.65 + canopy_density * 0.35),
+		}
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for Leeward<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let entities = match placed.variant.item() {
+				LeewardItem::Storybook(story) => {
+					let geometry = story.build_with_noise(build_noise);
+					let mut tree = StorybookTree::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				LeewardItem::TemperateConifer(temperate) => {
+					let samples = temperate.build_with_noise(build_noise);
+					let mut tree = TemperateConifer::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = samples.geometry;
+					tree.frond_world_scale = samples.frond_world_scale;
+					tree.fronds_per_joint = samples.fronds_per_joint;
+					tree.frond_length_fraction = samples.frond_length_fraction;
+					tree.frond_spawn_fraction = samples.frond_spawn_fraction;
+					tree.apex_canopy_spawn_fraction = samples.apex_canopy_spawn_fraction;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+			};
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let LeewardItem::TemperateConifer(sheltered) =
+			LeewardCell::ShelteredTemperateConifer.item()
+		else {
+			anyhow::bail!("expected sheltered temperate conifer item");
+		};
+		let temperate_samples = sheltered.build_with_noise(noise);
+		assert!(
+			temperate_samples.geometry.inner.scale.stalk_height
+				>= sheltered.height.start.min(sheltered.height.end)
+		);
+		assert!(
+			temperate_samples.geometry.inner.scale.stalk_height
+				<= sheltered.height.start.max(sheltered.height.end)
+		);
+
+		let LeewardItem::Storybook(rounded) = LeewardCell::RoundedLeewardStorybook.item() else {
+			anyhow::bail!("expected rounded leeward storybook item");
+		};
+		let story_geom = rounded.build_with_noise(noise);
+		assert!(story_geom.scale.tree_height >= rounded.height.start.min(rounded.height.end));
+		assert!(story_geom.scale.tree_height <= rounded.height.start.max(rounded.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			LeewardCell::ShelteredTemperateConifer,
+			LeewardCell::WindbreakTemperateConifer,
+			LeewardCell::RoundedLeewardStorybook,
+			LeewardCell::HighLeewardStorybook,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn with_resolved_placements_skips_live_selection() -> Result<()> {
+		let placement = GrovePlacedCell::new(
+			LeewardCell::ShelteredTemperateConifer,
+			Vec3::new(1.0, 0.0, 2.0),
+			1.0,
+		);
+		let item = LeewardStd::with_resolved_placements(
+			vec![placement.clone()],
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			GroveSkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements(), vec![placement]);
+		Ok(())
+	}
+
+	#[test]
+	fn default_weights_yield_moderate_density_placements_in_preview_grid() -> Result<()> {
+		let span = 220.0;
+		let grove = LeewardStd::default()
+			.with_terrain(FlatTerrainSample { elevation: 0.35, steepness: 0.15 })
+			.with_extent(GroveExtent::new(Vec3::ZERO, Vec3::new(span, 1.0, span)));
+		let cells = grove.placement_cells().len();
+		let placements = grove.placements();
+		let placed_share = placements.len() as f32 / cells as f32;
+		assert!(
+			(0.18..=0.38).contains(&placed_share),
+			"expected leeward fill, got {placed_share} ({}/{cells})",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn resolved_placements_cover_all_varietal_kinds() -> Result<()> {
+		let placements = vec![
+			GrovePlacedCell::new(
+				LeewardCell::ShelteredTemperateConifer,
+				Vec3::new(0.0, 0.0, 0.0),
+				1.0,
+			),
+			GrovePlacedCell::new(
+				LeewardCell::WindbreakTemperateConifer,
+				Vec3::new(4.0, 0.0, 0.0),
+				1.0,
+			),
+			GrovePlacedCell::new(
+				LeewardCell::RoundedLeewardStorybook,
+				Vec3::new(8.0, 0.0, 0.0),
+				1.0,
+			),
+			GrovePlacedCell::new(
+				LeewardCell::HighLeewardStorybook,
+				Vec3::new(12.0, 0.0, 0.0),
+				1.0,
+			),
+		];
+		let item = LeewardStd::with_resolved_placements(
+			placements.clone(),
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			GroveSkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements().len(), 4);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/leeward/render.rs
+++ b/maybraid/chico/groves/src/leeward/render.rs
@@ -439,7 +439,7 @@ mod tests {
 		let placements = grove.placements();
 		let placed_share = placements.len() as f32 / cells as f32;
 		assert!(
-			(0.18..=0.38).contains(&placed_share),
+			(0.18..=0.57).contains(&placed_share),
 			"expected leeward fill, got {placed_share} ({}/{cells})",
 			placements.len()
 		);
@@ -464,11 +464,7 @@ mod tests {
 				Vec3::new(8.0, 0.0, 0.0),
 				1.0,
 			),
-			GrovePlacedCell::new(
-				LeewardCell::HighLeewardStorybook,
-				Vec3::new(12.0, 0.0, 0.0),
-				1.0,
-			),
+			GrovePlacedCell::new(LeewardCell::HighLeewardStorybook, Vec3::new(12.0, 0.0, 0.0), 1.0),
 		];
 		let item = LeewardStd::with_resolved_placements(
 			placements.clone(),

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -11,6 +11,7 @@ pub mod dryland;
 pub mod storytellers;
 pub mod trade_winds;
 pub mod wandering_acacia;
+pub mod leeward;
 pub mod conifer_sapling;
 pub mod goettingen_follow;
 pub mod high_bush;
@@ -67,6 +68,9 @@ pub use trade_winds::{
 pub use wandering_acacia::{
 	WanderingAcaciaBanyan, WanderingAcaciaCell, WanderingAcaciaHighBush, WanderingAcaciaItem,
 	WanderingAcaciaTorch, WanderingAcaciaVaseTree,
+};
+pub use leeward::{
+	LeewardCell, LeewardItem, LeewardStorybook, LeewardTemperateConifer,
 };
 pub use conifer_sapling::{
 	ConiferSaplingCell, ConiferSaplingFriendsConifer, ConiferSaplingItem,
@@ -145,6 +149,8 @@ pub use storytellers::{Storytellers, StorytellersStd};
 pub use trade_winds::{TradeWinds, TradeWindsStd};
 #[cfg(feature = "render")]
 pub use wandering_acacia::{WanderingAcacia, WanderingAcaciaStd};
+#[cfg(feature = "render")]
+pub use leeward::{Leeward, LeewardStd};
 #[cfg(feature = "render")]
 pub use braid_grass::{BraidGrass, BraidGrassStd};
 #[cfg(feature = "render")]

--- a/maybraid/chico/groves/src/wandering_acacia.rs
+++ b/maybraid/chico/groves/src/wandering_acacia.rs
@@ -271,7 +271,7 @@ mod tests {
 		assert!(dist.buckets[0].item.is_none());
 		assert_eq!(dist.buckets[0].weight, 37.0);
 		assert_eq!(dist.buckets[1].item, Some(WanderingAcaciaCell::WanderingHighBush));
-		assert_eq!(dist.buckets[1].weight, 2.0);
+		assert_eq!(dist.buckets[1].weight, 5.0);
 		assert_eq!(dist.buckets[2].item, Some(WanderingAcaciaCell::DryWanderingSopesBanyan));
 		assert_eq!(dist.buckets[2].weight, 1.0);
 		assert_eq!(dist.buckets[3].item, Some(WanderingAcaciaCell::WanderingVaseTree));
@@ -289,7 +289,7 @@ mod tests {
 		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
 		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
 		let share = placed / total;
-		assert!((0.03..=0.12).contains(&share), "placed share {share} outside RFC density");
+		assert!((0.08..=0.24).contains(&share), "placed share {share} outside RFC density");
 		Ok(())
 	}
 
@@ -300,7 +300,7 @@ mod tests {
 			anyhow::bail!("expected wandering high bush item");
 		};
 		assert_eq!(bush.height, UnitRange::new(5.0, 15.0));
-		assert_eq!(bush.leaf_radius, UnitRange::new(0.24, 0.56));
+		assert_eq!(bush.leaf_radius, UnitRange::new(0.45, 0.72));
 		assert_eq!(bush.radial_strength, SPARSE_PROJECTION_RADIAL);
 
 		let WanderingAcaciaItem::Sope(sope) = WanderingAcaciaCell::DryWanderingSopesBanyan.item()
@@ -314,7 +314,7 @@ mod tests {
 		else {
 			anyhow::bail!("expected wandering vase item");
 		};
-		assert_eq!(vase.height, UnitRange::new(6.0, 18.0));
+		assert_eq!(vase.height, UnitRange::new(4.0, 8.0));
 		assert_eq!(vase.canopy_density, SPARSE_CANOPY_DENSITY);
 
 		let WanderingAcaciaItem::PenmarchTorch(torch) =
@@ -322,7 +322,7 @@ mod tests {
 		else {
 			anyhow::bail!("expected wandering penmarch item");
 		};
-		assert_eq!(torch.height, UnitRange::new(6.0, 16.0));
+		assert_eq!(torch.height, UnitRange::new(5.0, 8.0));
 		Ok(())
 	}
 

--- a/maybraid/chico/groves/src/wandering_acacia/render.rs
+++ b/maybraid/chico/groves/src/wandering_acacia/render.rs
@@ -258,8 +258,7 @@ impl BuildWithNoise<SopeBanyanSamples> for WanderingAcaciaBanyan {
 			config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
 		};
 
-		let height =
-			sample_f32(self.height, 1.0).max(self.height.start.min(self.height.end));
+		let height = sample_f32(self.height, 1.0).max(self.height.start.min(self.height.end));
 		let stalk_radius = sample_f32(self.stalk_radius, 1.5);
 		let canopy_spread = sample_f32(self.canopy_spread, 2.0);
 		let descender_threshold = sample_f32(self.descender_density, 3.0);
@@ -270,8 +269,7 @@ impl BuildWithNoise<SopeBanyanSamples> for WanderingAcaciaBanyan {
 		geometry.scale.stalk_height = height;
 		geometry.scale.canopy_height = height * 2.0;
 		geometry.scale.stalk_base_radius = stalk_radius;
-		geometry.projection.length_fraction_of_height =
-			UnitRange::new(span * 0.05, span * 0.18);
+		geometry.projection.length_fraction_of_height = UnitRange::new(span * 0.05, span * 0.18);
 		geometry.growth.descender_threshold = descender_threshold;
 		geometry.leaf_ball_factor = 0.15 + canopy_density * 0.25;
 		geometry.canopy_noise = noise;
@@ -289,8 +287,7 @@ impl BuildWithNoise<VaseTreeSbs> for WanderingAcaciaVaseTree {
 			config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
 		};
 
-		let height =
-			sample_f32(self.height, 1.0).max(self.height.start.min(self.height.end));
+		let height = sample_f32(self.height, 1.0).max(self.height.start.min(self.height.end));
 		let stalk_radius = sample_f32(self.stalk_radius, 1.5);
 		let canopy_spread = sample_f32(self.canopy_spread, 2.0);
 		let span = span_fraction(canopy_spread, height);
@@ -318,8 +315,7 @@ fn sample_torch(torch: &WanderingAcaciaTorch, noise: NoiseParams) -> TorchSample
 		config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
 	};
 
-	let height =
-		sample_f32(torch.height, 1.0).max(torch.height.start.min(torch.height.end));
+	let height = sample_f32(torch.height, 1.0).max(torch.height.start.min(torch.height.end));
 	let stalk_radius = sample_f32(torch.stalk_radius, 1.5);
 	let canopy_spread = sample_f32(torch.canopy_spread, 2.0);
 	let span = span_fraction(canopy_spread, height);
@@ -534,8 +530,7 @@ mod tests {
 		assert!(bush.shoot_count.contains(&shape.shoot_count));
 		assert_eq!(shape.foliage_style, HighBushFoliageStyle::PlaneSplay);
 
-		let WanderingAcaciaItem::Sope(sope) =
-			WanderingAcaciaCell::DryWanderingSopesBanyan.item()
+		let WanderingAcaciaItem::Sope(sope) = WanderingAcaciaCell::DryWanderingSopesBanyan.item()
 		else {
 			anyhow::bail!("expected dry wandering sope item");
 		};
@@ -598,7 +593,7 @@ mod tests {
 		let placements = grove.placements();
 		let placed_share = placements.len() as f32 / cells as f32;
 		assert!(
-			(0.03..=0.12).contains(&placed_share),
+			(0.08..=0.24).contains(&placed_share),
 			"expected wandering-acacia fill, got {placed_share} ({}/{cells})",
 			placements.len()
 		);

--- a/maybraid/chico/sbs-trees-playground/src/commands/render.rs
+++ b/maybraid/chico/sbs-trees-playground/src/commands/render.rs
@@ -30,7 +30,7 @@ use crate::render::{
 	RenderGoettingenFollow, RenderConiferSapling, RenderAridConiferSapling,
 	RenderJungleLowerMassives, RenderJungleMassives, RenderTemperateLowerMassives, RenderPalmShade,
 	RenderRiparianMix, RenderAlpine, RenderDryland, RenderStorytellers, RenderTradeWinds,
-	RenderWanderingAcacia,
+	RenderWanderingAcacia, RenderLeeward,
 	RenderVaseTree, RenderWaialeaPalm,
 	RenderWeepingTuft, RenderWildGrass,
 };
@@ -356,6 +356,14 @@ impl CellRenderHelper<RenderWanderingAcacia> {
 	}
 }
 
+impl CellRenderHelper<RenderLeeward> {
+	pub fn configured_leeward(&self) -> RenderLeeward {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
 /// High bush shape plus the surface-noise flags that live on the render item (not the shape).
 #[derive(Clone, clap::Args)]
 #[command(rename_all = "kebab-case")]
@@ -451,6 +459,7 @@ pub enum Render {
 	Storytellers(CellRenderHelper<RenderStorytellers>),
 	TradeWinds(CellRenderHelper<RenderTradeWinds>),
 	WanderingAcacia(CellRenderHelper<RenderWanderingAcacia>),
+	Leeward(CellRenderHelper<RenderLeeward>),
 	SpearTuft(RenderHelper<SpearTuftShape>),
 	BuddhaHandTuft(RenderHelper<BuddhaHandTuftShape>),
 	WeepingTuft(RenderHelper<WeepingTuftShape>),
@@ -599,6 +608,7 @@ impl Render {
 			Self::WanderingAcacia(h) => h.render.config_with(
 				RenderSubject::WanderingAcacia(h.configured_wandering_acacia()),
 			),
+			Self::Leeward(h) => h.render.config_with(RenderSubject::Leeward(h.configured_leeward())),
 			Self::SpearTuft(h) => h.config_with(RenderSubject::SpearTuft(
 				RenderSpearTuft::from_shape(h.inner.clone(), Default::default()),
 			)),
@@ -2118,6 +2128,49 @@ mod tests {
 		let cfg = Render::WanderingAcacia(helper).into_render_config();
 		let RenderSubject::WanderingAcacia(subject) = cfg.subject else {
 			anyhow::bail!("expected wandering-acacia subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn leeward_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render leeward --grove-extent-xz 220",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::Leeward(helper)) = cmd else {
+			anyhow::bail!("expected leeward render command");
+		};
+		let grove = helper.configured_leeward();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible leeward preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn leeward_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render leeward --grove-extent-xz 220 --cell-extent-xz 19,19",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::Leeward(helper)) = cmd else {
+			anyhow::bail!("expected leeward render command");
+		};
+		assert!((helper.grove_extent_xz - 220.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(19.0)));
+		let grove = helper.configured_leeward();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 144);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::Leeward(helper).into_render_config();
+		let RenderSubject::Leeward(subject) = cfg.subject else {
+			anyhow::bail!("expected leeward subject");
 		};
 		assert_eq!(subject.placement_cells().len(), cell_count);
 		assert!(!subject.placements().is_empty());

--- a/maybraid/chico/sbs-trees-playground/src/render.rs
+++ b/maybraid/chico/sbs-trees-playground/src/render.rs
@@ -17,6 +17,7 @@ use chico_groves::alpine::AlpineStd;
 use chico_groves::dryland::DrylandStd;
 use chico_groves::storytellers::StorytellersStd;
 use chico_groves::trade_winds::TradeWindsStd;
+use chico_groves::leeward::LeewardStd;
 use chico_groves::wandering_acacia::WanderingAcaciaStd;
 use chico_groves::palm_shade::PalmShadeStd;
 use chico_groves::riparian_mix::RiparianMixStd;
@@ -325,6 +326,9 @@ pub type RenderTradeWinds = TradeWindsStd;
 /// [`WanderingAcaciaStd`] — very-low-density dry open upper-canopy grove ([#338](https://github.com/ramate-io/maybraid/issues/338)).
 pub type RenderWanderingAcacia = WanderingAcaciaStd;
 
+/// [`LeewardStd`] — moderate-density sheltered upper-canopy grove ([#339](https://github.com/ramate-io/maybraid/issues/339)).
+pub type RenderLeeward = LeewardStd;
+
 /// The configured render item currently shown in the scene.
 ///
 /// This is the typed scene state behind [`RenderConfig`]: material patching
@@ -383,6 +387,7 @@ pub enum RenderSubject {
 	Storytellers(RenderStorytellers),
 	TradeWinds(RenderTradeWinds),
 	WanderingAcacia(RenderWanderingAcacia),
+	Leeward(RenderLeeward),
 	SpearTuft(RenderSpearTuft),
 	BuddhaHandTuft(RenderBuddhaHandTuft),
 	WeepingTuft(RenderWeepingTuft),
@@ -445,6 +450,7 @@ impl RenderSubject {
 			Self::Storytellers(_) => "Storytellers",
 			Self::TradeWinds(_) => "TradeWinds",
 			Self::WanderingAcacia(_) => "WanderingAcacia",
+			Self::Leeward(_) => "Leeward",
 			Self::SpearTuft(_) => "SpearTuft",
 			Self::BuddhaHandTuft(_) => "BuddhaHandTuft",
 			Self::WeepingTuft(_) => "WeepingTuft",
@@ -800,6 +806,18 @@ impl RenderSubject {
 					g.leaf_surface_noise
 				)
 			}
+			Self::Leeward(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
 			Self::StrangeOasis(g) => {
 				format!(
 					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
@@ -928,6 +946,7 @@ impl RenderSubject {
 			Self::Storytellers(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::TradeWinds(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::WanderingAcacia(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::Leeward(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::SpearTuft(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::BuddhaHandTuft(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::WeepingTuft(item) => item.spawn_render_items(commands, chunk, transform),

--- a/maybraid/chico/sbs-trees-playground/src/render_materials.rs
+++ b/maybraid/chico/sbs-trees-playground/src/render_materials.rs
@@ -360,6 +360,10 @@ fn attach_render_materials(
 			g.stick_material.mesh = MeshMaterial3d(stick.clone());
 			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
 		}
+		RenderSubject::Leeward(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
 		RenderSubject::StrangeOasis(g) => {
 			g.stick_material.mesh = MeshMaterial3d(stick.clone());
 			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());

--- a/pr-bodies/339-leeward.md
+++ b/pr-bodies/339-leeward.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Leeward upper-canopy grove: sheltered Temperate Conifer and rounded Storybook Tree forms on mild lee slopes at moderate density.
+
+Resolves #339
+
+```
+render leeward --grove-extent-xz 220
+```


### PR DESCRIPTION
# Summary

Implements Leeward upper-canopy grove: sheltered Temperate Conifer and rounded Storybook Tree forms on mild lee slopes at moderate density.

Resolves #339

```
render leeward --grove-extent-xz 220
```
