### PR TITLE
feat(groves): Christmas Taiga upper-canopy grove (#341)

### DIFF
--- a/maybraid/chico/groves/src/christmas_taiga.rs
+++ b/maybraid/chico/groves/src/christmas_taiga.rs
@@ -1,0 +1,212 @@
+//! Christmas Taiga — moderate-density cold Northern Conifer upper-canopy grove
+//! ([RFC-183 §3.4.7.18], [#341](https://github.com/ramate-io/maybraid/issues/341)).
+//!
+//! Dense cold-forest Northern Conifer forms with a colder high-band variant. Forest-layer attachment
+//! remains a follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{ChristmasTaiga, ChristmasTaigaStd};
+
+/// Dense sampled canopy-density band ([`0.50`, `0.85`]).
+const DENSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.50, 0.85);
+
+/// Authored Christmas Taiga grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`16.0` m). The offset range is signed and ± one cell so
+/// placements break the underlying grid instead of clustering near cell centers.
+pub fn definition() -> GroveDefinition<ChristmasTaigaCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(16.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-16.0, 16.0),
+		),
+		distribution: ChristmasTaigaCell::distribution(),
+	}
+}
+
+/// Ordered christmas-taiga varietals ([RFC-183 §3.4.7.18]); the explicit `None` bucket lives only in
+/// the distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChristmasTaigaCell {
+	ChristmasNorthernConifer,
+	HighBandNorthernConifer,
+}
+
+/// Typed authored geometry for one christmas-taiga varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ChristmasTaigaItem {
+	NorthernConifer(&'static ChristmasTaigaNorthernConifer),
+}
+
+/// Authored geometry ranges for one Northern Conifer form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChristmasTaigaNorthernConifer {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const CHRISTMAS_NORTHERN_CONIFER: ChristmasTaigaNorthernConifer = ChristmasTaigaNorthernConifer {
+	height: UnitRange::new(8.0, 20.0),
+	stalk_radius: UnitRange::new(0.22, 0.65),
+	canopy_spread: UnitRange::new(2.0, 6.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const HIGH_BAND_NORTHERN_CONIFER: ChristmasTaigaNorthernConifer = ChristmasTaigaNorthernConifer {
+	height: UnitRange::new(8.0, 20.0),
+	stalk_radius: UnitRange::new(0.22, 0.65),
+	canopy_spread: UnitRange::new(2.0, 6.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const CHRISTMAS_NORTHERN_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("cold_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "conifer_bark"),
+]);
+
+const CHRISTMAS_NORTHERN_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("christmas_green", "deep_green"),
+	PaletteSlot::new("blue_green", "dark_green"),
+]);
+
+const HIGH_BAND_NORTHERN_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("cold_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "conifer_bark"),
+]);
+
+const HIGH_BAND_NORTHERN_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("cold_green", "blue_green"),
+	PaletteSlot::new("deep_green", "dark_green"),
+]);
+
+impl ChristmasTaigaCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `1.5`; the `None` weight of `3.3` puts the placed share at
+	/// `1.5 / 4.8 ≈ 0.31`, mid RFC `DENSITY_RANGE` (`0.20..0.42`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let christmas_northern =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.76));
+		let high_band_northern =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.82));
+		GroveDistribution::new(vec![
+			GroveBucket::none(3.3),
+			GroveBucket::placed(1.0, christmas_northern, Self::ChristmasNorthernConifer),
+			GroveBucket::placed(0.5, high_band_northern, Self::HighBandNorthernConifer),
+		])
+	}
+
+	pub fn item(self) -> ChristmasTaigaItem {
+		match self {
+			Self::ChristmasNorthernConifer => {
+				ChristmasTaigaItem::NorthernConifer(&CHRISTMAS_NORTHERN_CONIFER)
+			}
+			Self::HighBandNorthernConifer => {
+				ChristmasTaigaItem::NorthernConifer(&HIGH_BAND_NORTHERN_CONIFER)
+			}
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::ChristmasNorthernConifer => CHRISTMAS_NORTHERN_STICK_MIX,
+			Self::HighBandNorthernConifer => HIGH_BAND_NORTHERN_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::ChristmasNorthernConifer => CHRISTMAS_NORTHERN_CANOPY_MIX,
+			Self::HighBandNorthernConifer => HIGH_BAND_NORTHERN_CANOPY_MIX,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = ChristmasTaigaCell::distribution();
+		assert_eq!(dist.len(), 3);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 3.3);
+		assert_eq!(dist.buckets[1].item, Some(ChristmasTaigaCell::ChristmasNorthernConifer));
+		assert_eq!(dist.buckets[1].weight, 1.0);
+		assert_eq!(dist.buckets[2].item, Some(ChristmasTaigaCell::HighBandNorthernConifer));
+		assert_eq!(dist.buckets[2].weight, 0.5);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = ChristmasTaigaCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.20..=0.42).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let ChristmasTaigaItem::NorthernConifer(christmas) =
+			ChristmasTaigaCell::ChristmasNorthernConifer.item()
+		else {
+			anyhow::bail!("expected christmas northern conifer item");
+		};
+		assert_eq!(christmas.height, UnitRange::new(8.0, 20.0));
+		assert_eq!(christmas.canopy_density, DENSE_CANOPY_DENSITY);
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [ChristmasTaigaCell::ChristmasNorthernConifer, ChristmasTaigaCell::HighBandNorthernConifer]
+		{
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(200.0, 1.0, 200.0));
+		let terrain = FlatTerrainSample::default();
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/christmas_taiga/render.rs
+++ b/maybraid/chico/groves/src/christmas_taiga/render.rs
@@ -1,0 +1,330 @@
+//! [`RenderItem`] for populated Christmas Taiga groves ([#341](https://github.com/ramate-io/maybraid/issues/341)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::NorthernConiferSbs;
+use chico_sbs_trees::northern_conifer::NorthernConifer;
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::christmas_taiga::{
+	definition, ChristmasTaigaCell, ChristmasTaigaItem, ChristmasTaigaNorthernConifer,
+};
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+
+const NORTHERN_SPLAY_RADIUS_FRACTION: f32 = 0.048;
+
+fn moderate_density_fraction(canopy_density: f32) -> f32 {
+	(0.55 + canopy_density * 0.35).clamp(0.55, 0.90)
+}
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Christmas Taiga instance.
+pub type ChristmasTaigaStd = ChristmasTaiga<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Christmas Taiga grove preview (cold dense Northern Conifer forms).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct ChristmasTaiga<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<ChristmasTaigaCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for ChristmasTaiga<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> ChristmasTaiga<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<ChristmasTaigaCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<ChristmasTaigaCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+struct NorthernConiferSamples {
+	geometry: NorthernConiferSbs,
+	splay_radius_fraction_of_height: f32,
+	splay_spawn_fraction: f32,
+	apex_canopy_spawn_fraction: f32,
+}
+
+impl BuildWithNoise<NorthernConiferSamples> for ChristmasTaigaNorthernConifer {
+	fn build_with_noise(&self, noise: NoiseParams) -> NorthernConiferSamples {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 3.0);
+		let density = moderate_density_fraction(canopy_density);
+
+		let mut geometry = NorthernConiferSbs::default();
+		geometry.liams.scale.stalk_height = height;
+		geometry.liams.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.apply_northern_preset();
+		geometry.liams.canopy_noise = noise;
+
+		NorthernConiferSamples {
+			geometry,
+			splay_radius_fraction_of_height: (canopy_spread / height)
+				.clamp(0.02, NORTHERN_SPLAY_RADIUS_FRACTION * 1.25),
+			splay_spawn_fraction: (0.40 + density * 0.45).clamp(0.55, 0.85),
+			apex_canopy_spawn_fraction: density,
+		}
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for ChristmasTaiga<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let entities = match placed.variant.item() {
+				ChristmasTaigaItem::NorthernConifer(conifer) => {
+					let samples = conifer.build_with_noise(build_noise);
+					let mut tree = NorthernConifer::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = samples.geometry;
+					tree.splay_radius_fraction_of_height = samples.splay_radius_fraction_of_height;
+					tree.splay_spawn_fraction = samples.splay_spawn_fraction;
+					tree.apex_canopy_spawn_fraction = samples.apex_canopy_spawn_fraction;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+			};
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+		let ChristmasTaigaItem::NorthernConifer(christmas) =
+			ChristmasTaigaCell::ChristmasNorthernConifer.item()
+		else {
+			anyhow::bail!("expected christmas northern conifer item");
+		};
+		let samples = christmas.build_with_noise(noise);
+		assert!(samples.geometry.liams.scale.stalk_height >= christmas.height.start.min(christmas.height.end));
+		assert!(samples.geometry.liams.scale.stalk_height <= christmas.height.start.max(christmas.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn default_weights_yield_moderate_density_placements_in_preview_grid() -> Result<()> {
+		let span = 200.0;
+		let grove = ChristmasTaigaStd::default()
+			.with_terrain(FlatTerrainSample { elevation: 0.50, steepness: 0.30 })
+			.with_extent(GroveExtent::new(Vec3::ZERO, Vec3::new(span, 1.0, span)));
+		let cells = grove.placement_cells().len();
+		let placements = grove.placements();
+		let placed_share = placements.len() as f32 / cells as f32;
+		assert!(
+			(0.20..=0.42).contains(&placed_share),
+			"expected christmas-taiga fill, got {placed_share} ({}/{cells})",
+			placements.len()
+		);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/grove/palette.rs
+++ b/maybraid/chico/groves/src/grove/palette.rs
@@ -156,6 +156,7 @@ pub fn resolve_palette_color(name: &str) -> Option<Color> {
 		"wind_barked" => Color::srgb(0.42, 0.38, 0.32),
 		"stone_gray" => Color::srgb(0.48, 0.46, 0.44),
 		"cold_green" => Color::srgb(0.16, 0.38, 0.32),
+		"christmas_green" => Color::srgb(0.14, 0.42, 0.22),
 		"dry_conifer_bark" => Color::srgb(0.42, 0.34, 0.24),
 		"sun_baked_bark" => Color::srgb(0.62, 0.52, 0.38),
 		"sage_green" => Color::srgb(0.42, 0.48, 0.32),
@@ -207,6 +208,7 @@ pub fn resolve_palette_color(name: &str) -> Option<Color> {
 		"deep_blue_green" => Color::srgb(0.12, 0.38, 0.42),
 		"acacia_bark" => Color::srgb(0.55, 0.42, 0.28),
 		"dry_banyan_bark" => Color::srgb(0.48, 0.38, 0.28),
+		"willow_bark" => Color::srgb(0.42, 0.34, 0.24),
 		_ => return None,
 	})
 }

--- a/maybraid/chico/groves/src/leeward.rs
+++ b/maybraid/chico/groves/src/leeward.rs
@@ -30,7 +30,7 @@ const DENSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.50, 0.85);
 /// placements break the underlying grid instead of clustering near cell centers.
 pub fn definition() -> GroveDefinition<LeewardCell> {
 	GroveDefinition {
-		cell_extent_xz: Vec2::splat(9.0),
+		cell_extent_xz: Vec2::splat(19.0),
 		placement: GrovePlacementRanges::new(
 			UnitRange::new(0.85, 1.15),
 			UnitRange::new(-19.0, 19.0),

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -12,6 +12,7 @@ pub mod storytellers;
 pub mod trade_winds;
 pub mod wandering_acacia;
 pub mod leeward;
+pub mod christmas_taiga;
 pub mod conifer_sapling;
 pub mod goettingen_follow;
 pub mod high_bush;
@@ -71,6 +72,9 @@ pub use wandering_acacia::{
 };
 pub use leeward::{
 	LeewardCell, LeewardItem, LeewardStorybook, LeewardTemperateConifer,
+};
+pub use christmas_taiga::{
+	ChristmasTaigaCell, ChristmasTaigaItem, ChristmasTaigaNorthernConifer,
 };
 pub use conifer_sapling::{
 	ConiferSaplingCell, ConiferSaplingFriendsConifer, ConiferSaplingItem,
@@ -151,6 +155,8 @@ pub use trade_winds::{TradeWinds, TradeWindsStd};
 pub use wandering_acacia::{WanderingAcacia, WanderingAcaciaStd};
 #[cfg(feature = "render")]
 pub use leeward::{Leeward, LeewardStd};
+#[cfg(feature = "render")]
+pub use christmas_taiga::{ChristmasTaiga, ChristmasTaigaStd};
 #[cfg(feature = "render")]
 pub use braid_grass::{BraidGrass, BraidGrassStd};
 #[cfg(feature = "render")]

--- a/maybraid/chico/sbs-trees-playground/src/commands/render.rs
+++ b/maybraid/chico/sbs-trees-playground/src/commands/render.rs
@@ -30,7 +30,7 @@ use crate::render::{
 	RenderGoettingenFollow, RenderConiferSapling, RenderAridConiferSapling,
 	RenderJungleLowerMassives, RenderJungleMassives, RenderTemperateLowerMassives, RenderPalmShade,
 	RenderRiparianMix, RenderAlpine, RenderDryland, RenderStorytellers, RenderTradeWinds,
-	RenderWanderingAcacia, RenderLeeward,
+	RenderWanderingAcacia, RenderLeeward, RenderChristmasTaiga,
 	RenderVaseTree, RenderWaialeaPalm,
 	RenderWeepingTuft, RenderWildGrass,
 };
@@ -364,6 +364,14 @@ impl CellRenderHelper<RenderLeeward> {
 	}
 }
 
+impl CellRenderHelper<RenderChristmasTaiga> {
+	pub fn configured_christmas_taiga(&self) -> RenderChristmasTaiga {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
 /// High bush shape plus the surface-noise flags that live on the render item (not the shape).
 #[derive(Clone, clap::Args)]
 #[command(rename_all = "kebab-case")]
@@ -460,6 +468,7 @@ pub enum Render {
 	TradeWinds(CellRenderHelper<RenderTradeWinds>),
 	WanderingAcacia(CellRenderHelper<RenderWanderingAcacia>),
 	Leeward(CellRenderHelper<RenderLeeward>),
+	ChristmasTaiga(CellRenderHelper<RenderChristmasTaiga>),
 	SpearTuft(RenderHelper<SpearTuftShape>),
 	BuddhaHandTuft(RenderHelper<BuddhaHandTuftShape>),
 	WeepingTuft(RenderHelper<WeepingTuftShape>),
@@ -609,6 +618,9 @@ impl Render {
 				RenderSubject::WanderingAcacia(h.configured_wandering_acacia()),
 			),
 			Self::Leeward(h) => h.render.config_with(RenderSubject::Leeward(h.configured_leeward())),
+			Self::ChristmasTaiga(h) => h.render.config_with(
+				RenderSubject::ChristmasTaiga(h.configured_christmas_taiga()),
+			),
 			Self::SpearTuft(h) => h.config_with(RenderSubject::SpearTuft(
 				RenderSpearTuft::from_shape(h.inner.clone(), Default::default()),
 			)),
@@ -2171,6 +2183,49 @@ mod tests {
 		let cfg = Render::Leeward(helper).into_render_config();
 		let RenderSubject::Leeward(subject) = cfg.subject else {
 			anyhow::bail!("expected leeward subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn christmas_taiga_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render christmas-taiga --grove-extent-xz 200",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::ChristmasTaiga(helper)) = cmd else {
+			anyhow::bail!("expected christmas-taiga render command");
+		};
+		let grove = helper.configured_christmas_taiga();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible christmas-taiga preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn christmas_taiga_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render christmas-taiga --grove-extent-xz 200 --cell-extent-xz 16,16",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::ChristmasTaiga(helper)) = cmd else {
+			anyhow::bail!("expected christmas-taiga render command");
+		};
+		assert!((helper.grove_extent_xz - 200.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(16.0)));
+		let grove = helper.configured_christmas_taiga();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 169);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::ChristmasTaiga(helper).into_render_config();
+		let RenderSubject::ChristmasTaiga(subject) = cfg.subject else {
+			anyhow::bail!("expected christmas-taiga subject");
 		};
 		assert_eq!(subject.placement_cells().len(), cell_count);
 		assert!(!subject.placements().is_empty());

--- a/maybraid/chico/sbs-trees-playground/src/render.rs
+++ b/maybraid/chico/sbs-trees-playground/src/render.rs
@@ -17,6 +17,7 @@ use chico_groves::alpine::AlpineStd;
 use chico_groves::dryland::DrylandStd;
 use chico_groves::storytellers::StorytellersStd;
 use chico_groves::trade_winds::TradeWindsStd;
+use chico_groves::christmas_taiga::ChristmasTaigaStd;
 use chico_groves::leeward::LeewardStd;
 use chico_groves::wandering_acacia::WanderingAcaciaStd;
 use chico_groves::palm_shade::PalmShadeStd;
@@ -329,6 +330,9 @@ pub type RenderWanderingAcacia = WanderingAcaciaStd;
 /// [`LeewardStd`] — moderate-density sheltered upper-canopy grove ([#339](https://github.com/ramate-io/maybraid/issues/339)).
 pub type RenderLeeward = LeewardStd;
 
+/// [`ChristmasTaigaStd`] — moderate-density cold Northern Conifer upper-canopy grove ([#341](https://github.com/ramate-io/maybraid/issues/341)).
+pub type RenderChristmasTaiga = ChristmasTaigaStd;
+
 /// The configured render item currently shown in the scene.
 ///
 /// This is the typed scene state behind [`RenderConfig`]: material patching
@@ -388,6 +392,7 @@ pub enum RenderSubject {
 	TradeWinds(RenderTradeWinds),
 	WanderingAcacia(RenderWanderingAcacia),
 	Leeward(RenderLeeward),
+	ChristmasTaiga(RenderChristmasTaiga),
 	SpearTuft(RenderSpearTuft),
 	BuddhaHandTuft(RenderBuddhaHandTuft),
 	WeepingTuft(RenderWeepingTuft),
@@ -451,6 +456,7 @@ impl RenderSubject {
 			Self::TradeWinds(_) => "TradeWinds",
 			Self::WanderingAcacia(_) => "WanderingAcacia",
 			Self::Leeward(_) => "Leeward",
+			Self::ChristmasTaiga(_) => "ChristmasTaiga",
 			Self::SpearTuft(_) => "SpearTuft",
 			Self::BuddhaHandTuft(_) => "BuddhaHandTuft",
 			Self::WeepingTuft(_) => "WeepingTuft",
@@ -818,6 +824,18 @@ impl RenderSubject {
 					g.leaf_surface_noise
 				)
 			}
+			Self::ChristmasTaiga(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
 			Self::StrangeOasis(g) => {
 				format!(
 					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
@@ -947,6 +965,7 @@ impl RenderSubject {
 			Self::TradeWinds(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::WanderingAcacia(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::Leeward(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::ChristmasTaiga(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::SpearTuft(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::BuddhaHandTuft(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::WeepingTuft(item) => item.spawn_render_items(commands, chunk, transform),

--- a/maybraid/chico/sbs-trees-playground/src/render_materials.rs
+++ b/maybraid/chico/sbs-trees-playground/src/render_materials.rs
@@ -364,6 +364,10 @@ fn attach_render_materials(
 			g.stick_material.mesh = MeshMaterial3d(stick.clone());
 			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
 		}
+		RenderSubject::ChristmasTaiga(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
 		RenderSubject::StrangeOasis(g) => {
 			g.stick_material.mesh = MeshMaterial3d(stick.clone());
 			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());

--- a/pr-bodies/341-christmas-taiga.md
+++ b/pr-bodies/341-christmas-taiga.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Christmas Taiga upper-canopy grove: dense cold Northern Conifer forms with a colder high-band variant.
+
+Resolves #341
+
+```
+render christmas-taiga --grove-extent-xz 200
+```


### PR DESCRIPTION
## Summary

Implements Christmas Taiga upper-canopy grove: dense cold Northern Conifer forms with a colder high-band variant.

Resolves #341

```
render christmas-taiga --grove-extent-xz 200
```

## Test plan

- [x] `cargo test -p chico-groves christmas_taiga`
- [x] `cargo test -p chico-sbs-trees-playground christmas_taiga`


Made with [Cursor](https://cursor.com)