### PR TITLE
feat(groves): Date Grove upper-canopy grove (#357)

### DIFF
--- a/maybraid/chico/groves/src/christmas_taiga.rs
+++ b/maybraid/chico/groves/src/christmas_taiga.rs
@@ -1,0 +1,212 @@
+//! Christmas Taiga — moderate-density cold Northern Conifer upper-canopy grove
+//! ([RFC-183 §3.4.7.18], [#341](https://github.com/ramate-io/maybraid/issues/341)).
+//!
+//! Dense cold-forest Northern Conifer forms with a colder high-band variant. Forest-layer attachment
+//! remains a follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{ChristmasTaiga, ChristmasTaigaStd};
+
+/// Dense sampled canopy-density band ([`0.50`, `0.85`]).
+const DENSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.50, 0.85);
+
+/// Authored Christmas Taiga grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`16.0` m). The offset range is signed and ± one cell so
+/// placements break the underlying grid instead of clustering near cell centers.
+pub fn definition() -> GroveDefinition<ChristmasTaigaCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(16.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-16.0, 16.0),
+		),
+		distribution: ChristmasTaigaCell::distribution(),
+	}
+}
+
+/// Ordered christmas-taiga varietals ([RFC-183 §3.4.7.18]); the explicit `None` bucket lives only in
+/// the distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChristmasTaigaCell {
+	ChristmasNorthernConifer,
+	HighBandNorthernConifer,
+}
+
+/// Typed authored geometry for one christmas-taiga varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ChristmasTaigaItem {
+	NorthernConifer(&'static ChristmasTaigaNorthernConifer),
+}
+
+/// Authored geometry ranges for one Northern Conifer form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChristmasTaigaNorthernConifer {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const CHRISTMAS_NORTHERN_CONIFER: ChristmasTaigaNorthernConifer = ChristmasTaigaNorthernConifer {
+	height: UnitRange::new(8.0, 20.0),
+	stalk_radius: UnitRange::new(0.22, 0.65),
+	canopy_spread: UnitRange::new(2.0, 6.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const HIGH_BAND_NORTHERN_CONIFER: ChristmasTaigaNorthernConifer = ChristmasTaigaNorthernConifer {
+	height: UnitRange::new(8.0, 20.0),
+	stalk_radius: UnitRange::new(0.22, 0.65),
+	canopy_spread: UnitRange::new(2.0, 6.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const CHRISTMAS_NORTHERN_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("cold_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "conifer_bark"),
+]);
+
+const CHRISTMAS_NORTHERN_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("christmas_green", "deep_green"),
+	PaletteSlot::new("blue_green", "dark_green"),
+]);
+
+const HIGH_BAND_NORTHERN_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("cold_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "conifer_bark"),
+]);
+
+const HIGH_BAND_NORTHERN_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("cold_green", "blue_green"),
+	PaletteSlot::new("deep_green", "dark_green"),
+]);
+
+impl ChristmasTaigaCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `1.5`; the `None` weight of `3.3` puts the placed share at
+	/// `1.5 / 4.8 ≈ 0.31`, mid RFC `DENSITY_RANGE` (`0.20..0.42`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let christmas_northern =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.76));
+		let high_band_northern =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.82));
+		GroveDistribution::new(vec![
+			GroveBucket::none(3.3),
+			GroveBucket::placed(1.0, christmas_northern, Self::ChristmasNorthernConifer),
+			GroveBucket::placed(0.5, high_band_northern, Self::HighBandNorthernConifer),
+		])
+	}
+
+	pub fn item(self) -> ChristmasTaigaItem {
+		match self {
+			Self::ChristmasNorthernConifer => {
+				ChristmasTaigaItem::NorthernConifer(&CHRISTMAS_NORTHERN_CONIFER)
+			}
+			Self::HighBandNorthernConifer => {
+				ChristmasTaigaItem::NorthernConifer(&HIGH_BAND_NORTHERN_CONIFER)
+			}
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::ChristmasNorthernConifer => CHRISTMAS_NORTHERN_STICK_MIX,
+			Self::HighBandNorthernConifer => HIGH_BAND_NORTHERN_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::ChristmasNorthernConifer => CHRISTMAS_NORTHERN_CANOPY_MIX,
+			Self::HighBandNorthernConifer => HIGH_BAND_NORTHERN_CANOPY_MIX,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = ChristmasTaigaCell::distribution();
+		assert_eq!(dist.len(), 3);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 3.3);
+		assert_eq!(dist.buckets[1].item, Some(ChristmasTaigaCell::ChristmasNorthernConifer));
+		assert_eq!(dist.buckets[1].weight, 1.0);
+		assert_eq!(dist.buckets[2].item, Some(ChristmasTaigaCell::HighBandNorthernConifer));
+		assert_eq!(dist.buckets[2].weight, 0.5);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = ChristmasTaigaCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.20..=0.42).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let ChristmasTaigaItem::NorthernConifer(christmas) =
+			ChristmasTaigaCell::ChristmasNorthernConifer.item()
+		else {
+			anyhow::bail!("expected christmas northern conifer item");
+		};
+		assert_eq!(christmas.height, UnitRange::new(8.0, 20.0));
+		assert_eq!(christmas.canopy_density, DENSE_CANOPY_DENSITY);
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [ChristmasTaigaCell::ChristmasNorthernConifer, ChristmasTaigaCell::HighBandNorthernConifer]
+		{
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(200.0, 1.0, 200.0));
+		let terrain = FlatTerrainSample::default();
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/christmas_taiga/render.rs
+++ b/maybraid/chico/groves/src/christmas_taiga/render.rs
@@ -1,0 +1,330 @@
+//! [`RenderItem`] for populated Christmas Taiga groves ([#341](https://github.com/ramate-io/maybraid/issues/341)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::NorthernConiferSbs;
+use chico_sbs_trees::northern_conifer::NorthernConifer;
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::christmas_taiga::{
+	definition, ChristmasTaigaCell, ChristmasTaigaItem, ChristmasTaigaNorthernConifer,
+};
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+
+const NORTHERN_SPLAY_RADIUS_FRACTION: f32 = 0.048;
+
+fn moderate_density_fraction(canopy_density: f32) -> f32 {
+	(0.55 + canopy_density * 0.35).clamp(0.55, 0.90)
+}
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Christmas Taiga instance.
+pub type ChristmasTaigaStd = ChristmasTaiga<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Christmas Taiga grove preview (cold dense Northern Conifer forms).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct ChristmasTaiga<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<ChristmasTaigaCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for ChristmasTaiga<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> ChristmasTaiga<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<ChristmasTaigaCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<ChristmasTaigaCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+struct NorthernConiferSamples {
+	geometry: NorthernConiferSbs,
+	splay_radius_fraction_of_height: f32,
+	splay_spawn_fraction: f32,
+	apex_canopy_spawn_fraction: f32,
+}
+
+impl BuildWithNoise<NorthernConiferSamples> for ChristmasTaigaNorthernConifer {
+	fn build_with_noise(&self, noise: NoiseParams) -> NorthernConiferSamples {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 3.0);
+		let density = moderate_density_fraction(canopy_density);
+
+		let mut geometry = NorthernConiferSbs::default();
+		geometry.liams.scale.stalk_height = height;
+		geometry.liams.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.apply_northern_preset();
+		geometry.liams.canopy_noise = noise;
+
+		NorthernConiferSamples {
+			geometry,
+			splay_radius_fraction_of_height: (canopy_spread / height)
+				.clamp(0.02, NORTHERN_SPLAY_RADIUS_FRACTION * 1.25),
+			splay_spawn_fraction: (0.40 + density * 0.45).clamp(0.55, 0.85),
+			apex_canopy_spawn_fraction: density,
+		}
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for ChristmasTaiga<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let entities = match placed.variant.item() {
+				ChristmasTaigaItem::NorthernConifer(conifer) => {
+					let samples = conifer.build_with_noise(build_noise);
+					let mut tree = NorthernConifer::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = samples.geometry;
+					tree.splay_radius_fraction_of_height = samples.splay_radius_fraction_of_height;
+					tree.splay_spawn_fraction = samples.splay_spawn_fraction;
+					tree.apex_canopy_spawn_fraction = samples.apex_canopy_spawn_fraction;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+			};
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+		let ChristmasTaigaItem::NorthernConifer(christmas) =
+			ChristmasTaigaCell::ChristmasNorthernConifer.item()
+		else {
+			anyhow::bail!("expected christmas northern conifer item");
+		};
+		let samples = christmas.build_with_noise(noise);
+		assert!(samples.geometry.liams.scale.stalk_height >= christmas.height.start.min(christmas.height.end));
+		assert!(samples.geometry.liams.scale.stalk_height <= christmas.height.start.max(christmas.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn default_weights_yield_moderate_density_placements_in_preview_grid() -> Result<()> {
+		let span = 200.0;
+		let grove = ChristmasTaigaStd::default()
+			.with_terrain(FlatTerrainSample { elevation: 0.50, steepness: 0.30 })
+			.with_extent(GroveExtent::new(Vec3::ZERO, Vec3::new(span, 1.0, span)));
+		let cells = grove.placement_cells().len();
+		let placements = grove.placements();
+		let placed_share = placements.len() as f32 / cells as f32;
+		assert!(
+			(0.20..=0.42).contains(&placed_share),
+			"expected christmas-taiga fill, got {placed_share} ({}/{cells})",
+			placements.len()
+		);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/conifer_massives.rs
+++ b/maybraid/chico/groves/src/conifer_massives.rs
@@ -1,0 +1,370 @@
+//! Conifer Massives — low-density giant evergreen upper-canopy grove
+//! ([RFC-183 §3.4.7.2], [#343](https://github.com/ramate-io/maybraid/issues/343)).
+//!
+//! Towering Northern, Friend's, Liam's, and Temperate Conifer skyline forms above conifer lower
+//! massives. Forest-layer attachment remains a follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{ConiferMassives, ConiferMassivesStd};
+
+/// Dense sampled canopy-density band ([`0.50`, `0.85`]).
+const DENSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.50, 0.85);
+/// Moderate sampled canopy-density band ([`0.35`, `0.65`]).
+const MODERATE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
+
+/// Authored Conifer Massives grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`50.0` m). The offset range is signed and ± one cell so
+/// placements break the underlying grid instead of clustering near cell centers.
+pub fn definition() -> GroveDefinition<ConiferMassivesCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(50.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-50.0, 50.0),
+		),
+		distribution: ConiferMassivesCell::distribution(),
+	}
+}
+
+/// Ordered conifer-massive varietals ([RFC-183 §3.4.7.2]); the explicit `None` bucket lives only in
+/// the distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConiferMassivesCell {
+	MassiveNorthernConifer,
+	MassiveFriendsConifer,
+	MassiveLiamsConifer,
+	MassiveTemperateConifer,
+}
+
+/// Typed authored geometry for one conifer-massive varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ConiferMassivesItem {
+	NorthernConifer(&'static ConiferMassivesNorthernConifer),
+	FriendsConifer(&'static ConiferMassivesFriendsConifer),
+	LiamsConifer(&'static ConiferMassivesLiamsConifer),
+	TemperateConifer(&'static ConiferMassivesTemperateConifer),
+}
+
+/// Authored geometry ranges for one Northern Conifer form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConiferMassivesNorthernConifer {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one Friend's Conifer form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConiferMassivesFriendsConifer {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one Liam's Conifer form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConiferMassivesLiamsConifer {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one Temperate Conifer form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConiferMassivesTemperateConifer {
+	pub height: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const MASSIVE_NORTHERN_CONIFER: ConiferMassivesNorthernConifer = ConiferMassivesNorthernConifer {
+	height: UnitRange::new(70.0, 200.0),
+	stalk_radius: UnitRange::new(2.0, 6.5),
+	canopy_spread: UnitRange::new(15.0, 45.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const MASSIVE_FRIENDS_CONIFER: ConiferMassivesFriendsConifer = ConiferMassivesFriendsConifer {
+	height: UnitRange::new(100.0, 130.0),
+	stalk_radius: UnitRange::new(2.5, 5.5),
+	canopy_spread: UnitRange::new(18.0, 35.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const MASSIVE_LIAMS_CONIFER: ConiferMassivesLiamsConifer = ConiferMassivesLiamsConifer {
+	height: UnitRange::new(25.0, 130.0),
+	stalk_radius: UnitRange::new(0.5, 4.5),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const MASSIVE_TEMPERATE_CONIFER: ConiferMassivesTemperateConifer =
+	ConiferMassivesTemperateConifer {
+		height: UnitRange::new(40.0, 120.0),
+		canopy_density: MODERATE_CANOPY_DENSITY,
+	};
+
+const NORTHERN_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("cold_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "conifer_bark"),
+]);
+
+const NORTHERN_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("cold_green", "blue_green"),
+	PaletteSlot::new("deep_green", "dark_green"),
+]);
+
+const FRIENDS_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("conifer_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "moss_bark"),
+]);
+
+const FRIENDS_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("deep_green", "blue_green"),
+	PaletteSlot::new("dark_green", "fresh_green"),
+]);
+
+const LIAMS_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("conifer_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "moss_bark"),
+]);
+
+const LIAMS_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("deep_green", "blue_green"),
+	PaletteSlot::new("dark_green", "fresh_green"),
+]);
+
+const TEMPERATE_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("temperate_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "moss_bark"),
+]);
+
+const TEMPERATE_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("soft_green", "deep_green"),
+	PaletteSlot::new("blue_green", "fresh_green"),
+]);
+
+impl ConiferMassivesCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `3.5`; the `None` weight of `23.0` puts the placed share at
+	/// `3.5 / 26.5 ≈ 0.132`, mid RFC `DENSITY_RANGE` (`0.06..0.20`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let northern =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.70));
+		let friends =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.64));
+		let liams =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.76));
+		let temperate =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.58));
+		GroveDistribution::new(vec![
+			GroveBucket::none(23.0),
+			GroveBucket::placed(1.25, northern, Self::MassiveNorthernConifer),
+			GroveBucket::placed(1.25, friends, Self::MassiveFriendsConifer),
+			GroveBucket::placed(0.75, liams, Self::MassiveLiamsConifer),
+			GroveBucket::placed(0.25, temperate, Self::MassiveTemperateConifer),
+		])
+	}
+
+	pub fn item(self) -> ConiferMassivesItem {
+		match self {
+			Self::MassiveNorthernConifer => {
+				ConiferMassivesItem::NorthernConifer(&MASSIVE_NORTHERN_CONIFER)
+			}
+			Self::MassiveFriendsConifer => {
+				ConiferMassivesItem::FriendsConifer(&MASSIVE_FRIENDS_CONIFER)
+			}
+			Self::MassiveLiamsConifer => ConiferMassivesItem::LiamsConifer(&MASSIVE_LIAMS_CONIFER),
+			Self::MassiveTemperateConifer => {
+				ConiferMassivesItem::TemperateConifer(&MASSIVE_TEMPERATE_CONIFER)
+			}
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::MassiveNorthernConifer => NORTHERN_STICK_MIX,
+			Self::MassiveFriendsConifer => FRIENDS_STICK_MIX,
+			Self::MassiveLiamsConifer => LIAMS_STICK_MIX,
+			Self::MassiveTemperateConifer => TEMPERATE_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::MassiveNorthernConifer => NORTHERN_CANOPY_MIX,
+			Self::MassiveFriendsConifer => FRIENDS_CANOPY_MIX,
+			Self::MassiveLiamsConifer => LIAMS_CANOPY_MIX,
+			Self::MassiveTemperateConifer => TEMPERATE_CANOPY_MIX,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveCellOutcome, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+	use procedural_common::NoiseParams;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = ConiferMassivesCell::distribution();
+		assert_eq!(dist.len(), 5);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 23.0);
+		assert_eq!(dist.buckets[1].item, Some(ConiferMassivesCell::MassiveNorthernConifer));
+		assert_eq!(dist.buckets[1].weight, 1.25);
+		assert_eq!(dist.buckets[2].item, Some(ConiferMassivesCell::MassiveFriendsConifer));
+		assert_eq!(dist.buckets[2].weight, 1.25);
+		assert_eq!(dist.buckets[3].item, Some(ConiferMassivesCell::MassiveLiamsConifer));
+		assert_eq!(dist.buckets[3].weight, 0.75);
+		assert_eq!(dist.buckets[4].item, Some(ConiferMassivesCell::MassiveTemperateConifer));
+		assert_eq!(dist.buckets[4].weight, 0.25);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = ConiferMassivesCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.06..=0.20).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let ConiferMassivesItem::NorthernConifer(northern) =
+			ConiferMassivesCell::MassiveNorthernConifer.item()
+		else {
+			anyhow::bail!("expected northern conifer item");
+		};
+		assert_eq!(northern.height, UnitRange::new(70.0, 200.0));
+		assert_eq!(northern.canopy_density, DENSE_CANOPY_DENSITY);
+
+		let ConiferMassivesItem::FriendsConifer(friends) =
+			ConiferMassivesCell::MassiveFriendsConifer.item()
+		else {
+			anyhow::bail!("expected friends conifer item");
+		};
+		assert_eq!(friends.height, UnitRange::new(100.0, 130.0));
+
+		let ConiferMassivesItem::LiamsConifer(liams) =
+			ConiferMassivesCell::MassiveLiamsConifer.item()
+		else {
+			anyhow::bail!("expected liams conifer item");
+		};
+		assert_eq!(liams.height, UnitRange::new(25.0, 130.0));
+		assert_eq!(liams.canopy_density, MODERATE_CANOPY_DENSITY);
+
+		let ConiferMassivesItem::TemperateConifer(temperate) =
+			ConiferMassivesCell::MassiveTemperateConifer.item()
+		else {
+			anyhow::bail!("expected temperate conifer item");
+		};
+		assert_eq!(temperate.height, UnitRange::new(40.0, 120.0));
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_use_full_elevation_and_rfc_steepness() -> Result<()> {
+		let dist = ConiferMassivesCell::distribution();
+		for bucket in dist.buckets.iter().filter(|b| b.item.is_some()) {
+			assert_eq!(bucket.constraints.elevation.start, 0.0);
+			assert_eq!(bucket.constraints.elevation.end, 1.0);
+		}
+		let northern = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(ConiferMassivesCell::MassiveNorthernConifer))
+			.ok_or_else(|| anyhow::anyhow!("missing northern bucket"))?;
+		assert_eq!(northern.constraints.steepness.end, 0.70);
+
+		let friends = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(ConiferMassivesCell::MassiveFriendsConifer))
+			.ok_or_else(|| anyhow::anyhow!("missing friends bucket"))?;
+		assert_eq!(friends.constraints.steepness.end, 0.64);
+
+		let temperate = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(ConiferMassivesCell::MassiveTemperateConifer))
+			.ok_or_else(|| anyhow::anyhow!("missing temperate bucket"))?;
+		assert_eq!(temperate.constraints.steepness.end, 0.58);
+		Ok(())
+	}
+
+	#[test]
+	fn steep_slope_rejects_friends_but_allows_liams() -> Result<()> {
+		let prepared = ConiferMassivesCell::distribution().prepare(
+			0.0,
+			0.0,
+			NoiseParams::default(),
+			Vec3::ZERO,
+		);
+		let terrain = FlatTerrainSample { elevation: 0.40, steepness: 0.68 };
+		let outcome = prepared.select_from(3, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
+		match outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_ne!(variant, ConiferMassivesCell::MassiveFriendsConifer);
+				assert_ne!(variant, ConiferMassivesCell::MassiveNorthernConifer);
+			}
+			GroveCellOutcome::Empty { .. } | GroveCellOutcome::Rejected { .. } => {}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			ConiferMassivesCell::MassiveNorthernConifer,
+			ConiferMassivesCell::MassiveFriendsConifer,
+			ConiferMassivesCell::MassiveLiamsConifer,
+			ConiferMassivesCell::MassiveTemperateConifer,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(300.0, 1.0, 300.0));
+		let terrain = FlatTerrainSample::default();
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/conifer_massives/render.rs
+++ b/maybraid/chico/groves/src/conifer_massives/render.rs
@@ -1,0 +1,590 @@
+//! [`RenderItem`] for populated Conifer Massives groves ([#343](https://github.com/ramate-io/maybraid/issues/343)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::{FriendsConiferSbs, LiamsConiferSbs, NorthernConiferSbs};
+use chico_sbs_trees::friends_conifer::FriendsConifer;
+use chico_sbs_trees::liams_conifer::LiamsConifer;
+use chico_sbs_trees::northern_conifer::NorthernConifer;
+use chico_sbs_trees::temperate_conifer::{TemperateConifer, TemperateConiferGeometry};
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::UsizeRange;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::conifer_massives::{
+	definition, ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
+	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
+};
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Conifer Massives instance.
+pub type ConiferMassivesStd = ConiferMassives<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Conifer Massives grove preview (giant evergreen skyline forms).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct ConiferMassives<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<ConiferMassivesCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for ConiferMassives<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> ConiferMassives<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<ConiferMassivesCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<ConiferMassivesCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+fn span_fraction(canopy_spread: f32, height: f32) -> f32 {
+	(canopy_spread / height.max(0.5)).clamp(0.25, 1.20)
+}
+
+fn dense_density_fraction(canopy_density: f32) -> f32 {
+	canopy_density.clamp(0.50, 0.85)
+}
+
+fn moderate_density_fraction(canopy_density: f32) -> f32 {
+	canopy_density.clamp(0.35, 0.65)
+}
+
+/// Playground default from [`NorthernConifer`] (RFC `0.048 × H`).
+const NORTHERN_SPLAY_RADIUS_FRACTION: f32 = 0.048;
+
+struct NorthernConiferSamples {
+	geometry: NorthernConiferSbs,
+	splay_radius_fraction_of_height: f32,
+	splay_spawn_fraction: f32,
+	apex_canopy_spawn_fraction: f32,
+}
+
+impl BuildWithNoise<NorthernConiferSamples> for ConiferMassivesNorthernConifer {
+	fn build_with_noise(&self, noise: NoiseParams) -> NorthernConiferSamples {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 3.0);
+		let density = dense_density_fraction(canopy_density);
+
+		let mut geometry = NorthernConiferSbs::default();
+		geometry.liams.scale.stalk_height = height;
+		geometry.liams.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.apply_northern_preset();
+		geometry.liams.canopy_noise = noise;
+
+		NorthernConiferSamples {
+			geometry,
+			splay_radius_fraction_of_height: (canopy_spread / height)
+				.clamp(0.02, NORTHERN_SPLAY_RADIUS_FRACTION * 1.35),
+			splay_spawn_fraction: (0.45 + density * 0.40).clamp(0.55, 0.92),
+			apex_canopy_spawn_fraction: density,
+		}
+	}
+}
+
+struct FriendsConiferSamples {
+	geometry: FriendsConiferSbs,
+	apex_canopy_spawn_fraction: f32,
+	splay_radius_fraction_of_height: f32,
+}
+
+impl BuildWithNoise<FriendsConiferSamples> for ConiferMassivesFriendsConifer {
+	fn build_with_noise(&self, noise: NoiseParams) -> FriendsConiferSamples {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 3.0);
+		let span = span_fraction(canopy_spread, height);
+		let density = dense_density_fraction(canopy_density);
+
+		let mut geometry = FriendsConiferSbs::default();
+		geometry.scale.stalk_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.projection.length_fraction_of_height =
+			UnitRange::new(span * 0.95, (span * 0.35).max(0.03));
+		geometry.growth.branch_depth = 2;
+		geometry.rings.anchors_per_ring = 4;
+		geometry.canopy_noise = noise;
+
+		FriendsConiferSamples {
+			geometry,
+			apex_canopy_spawn_fraction: density,
+			splay_radius_fraction_of_height: (canopy_spread / height).clamp(0.014, 0.08),
+		}
+	}
+}
+
+impl BuildWithNoise<LiamsConiferSbs> for ConiferMassivesLiamsConifer {
+	fn build_with_noise(&self, noise: NoiseParams) -> LiamsConiferSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_density = sample_f32(&config, self.canopy_density, 2.0);
+
+		let mut geometry = LiamsConiferSbs::default();
+		geometry.rings.spacing = (0.02 + moderate_density_fraction(canopy_density) * 0.04)
+			.clamp(0.02, 0.06);
+		geometry.scale.stalk_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.canopy_noise = noise;
+		geometry
+	}
+}
+
+struct TemperateConiferSamples {
+	geometry: TemperateConiferGeometry,
+	fronds_per_joint: UnitRange,
+	frond_length_fraction: UnitRange,
+	frond_spawn_fraction: f32,
+	frond_world_scale: f32,
+	apex_canopy_spawn_fraction: f32,
+}
+
+impl BuildWithNoise<TemperateConiferSamples> for ConiferMassivesTemperateConifer {
+	fn build_with_noise(&self, noise: NoiseParams) -> TemperateConiferSamples {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let canopy_density = sample_f32(&config, self.canopy_density, 2.0);
+		let density = moderate_density_fraction(canopy_density);
+
+		let mut inner = FriendsConiferSbs::default();
+		inner.apply_temperate_preset();
+		inner.scale.stalk_height = height;
+		inner.scale.stalk_base_radius = Some((height * 0.025).clamp(0.35, 2.50));
+		inner.projection.child_count_range = UsizeRange::new(1, 3);
+		inner.canopy_noise = noise;
+
+		let frond_spawn_fraction = (0.45 + density * 0.45).clamp(0.45, 0.95);
+		let fronds_hi = 1.0 + (density * 1.2).round();
+		let frond_len_lo = 0.030 + density * 0.010;
+		let frond_len_hi = 0.045 + density * 0.030;
+
+		TemperateConiferSamples {
+			geometry: TemperateConiferGeometry { inner },
+			fronds_per_joint: UnitRange::new(1.0, fronds_hi),
+			frond_length_fraction: UnitRange::new(frond_len_lo, frond_len_hi),
+			frond_spawn_fraction,
+			frond_world_scale: 0.85 + density * 0.35,
+			apex_canopy_spawn_fraction: 0.72 * (0.65 + density * 0.35),
+		}
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for ConiferMassives<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let entities = match placed.variant.item() {
+				ConiferMassivesItem::NorthernConifer(conifer) => {
+					let samples = conifer.build_with_noise(build_noise);
+					let mut tree = NorthernConifer::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = samples.geometry;
+					tree.splay_radius_fraction_of_height = samples.splay_radius_fraction_of_height;
+					tree.splay_spawn_fraction = samples.splay_spawn_fraction;
+					tree.apex_canopy_spawn_fraction = samples.apex_canopy_spawn_fraction;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				ConiferMassivesItem::FriendsConifer(conifer) => {
+					let samples = conifer.build_with_noise(build_noise);
+					let mut tree = FriendsConifer::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = samples.geometry;
+					tree.splay_radius_fraction_of_height = samples.splay_radius_fraction_of_height;
+					tree.apex_canopy_spawn_fraction = samples.apex_canopy_spawn_fraction;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				ConiferMassivesItem::LiamsConifer(conifer) => {
+					let geometry = conifer.build_with_noise(build_noise);
+					let mut tree = LiamsConifer::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				ConiferMassivesItem::TemperateConifer(temperate) => {
+					let samples = temperate.build_with_noise(build_noise);
+					let mut tree = TemperateConifer::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = samples.geometry;
+					tree.frond_world_scale = samples.frond_world_scale;
+					tree.fronds_per_joint = samples.fronds_per_joint;
+					tree.frond_length_fraction = samples.frond_length_fraction;
+					tree.frond_spawn_fraction = samples.frond_spawn_fraction;
+					tree.apex_canopy_spawn_fraction = samples.apex_canopy_spawn_fraction;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+			};
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let ConiferMassivesItem::NorthernConifer(northern) =
+			ConiferMassivesCell::MassiveNorthernConifer.item()
+		else {
+			anyhow::bail!("expected northern conifer item");
+		};
+		let northern_samples = northern.build_with_noise(noise);
+		assert!(
+			northern_samples.geometry.liams.scale.stalk_height
+				>= northern.height.start.min(northern.height.end)
+		);
+		assert!(
+			northern_samples.geometry.liams.scale.stalk_height
+				<= northern.height.start.max(northern.height.end)
+		);
+
+		let ConiferMassivesItem::FriendsConifer(friends) =
+			ConiferMassivesCell::MassiveFriendsConifer.item()
+		else {
+			anyhow::bail!("expected friends conifer item");
+		};
+		let friends_samples = friends.build_with_noise(noise);
+		assert!(
+			friends_samples.geometry.scale.stalk_height
+				>= friends.height.start.min(friends.height.end)
+		);
+		assert!(
+			friends_samples.geometry.scale.stalk_height
+				<= friends.height.start.max(friends.height.end)
+		);
+
+		let ConiferMassivesItem::TemperateConifer(temperate) =
+			ConiferMassivesCell::MassiveTemperateConifer.item()
+		else {
+			anyhow::bail!("expected temperate conifer item");
+		};
+		let temperate_samples = temperate.build_with_noise(noise);
+		assert!(
+			temperate_samples.geometry.inner.scale.stalk_height
+				>= temperate.height.start.min(temperate.height.end)
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			ConiferMassivesCell::MassiveNorthernConifer,
+			ConiferMassivesCell::MassiveFriendsConifer,
+			ConiferMassivesCell::MassiveLiamsConifer,
+			ConiferMassivesCell::MassiveTemperateConifer,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn with_resolved_placements_skips_live_selection() -> Result<()> {
+		let placement = GrovePlacedCell::new(
+			ConiferMassivesCell::MassiveNorthernConifer,
+			Vec3::new(1.0, 0.0, 2.0),
+			1.0,
+		);
+		let item = ConiferMassivesStd::with_resolved_placements(
+			vec![placement.clone()],
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			GroveSkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements(), vec![placement]);
+		Ok(())
+	}
+
+	#[test]
+	fn default_weights_yield_sparse_density_in_preview_grid() -> Result<()> {
+		let span = 300.0;
+		let grove = ConiferMassivesStd::default()
+			.with_terrain(FlatTerrainSample { elevation: 0.35, steepness: 0.15 })
+			.with_extent(GroveExtent::new(Vec3::ZERO, Vec3::new(span, 1.0, span)));
+		let cells = grove.placement_cells().len();
+		let placements = grove.placements();
+		let placed_share = placements.len() as f32 / cells as f32;
+		assert!(
+			(0.06..=0.22).contains(&placed_share),
+			"expected conifer-massive fill, got {placed_share} ({}/{cells})",
+			placements.len()
+		);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/date_grove.rs
+++ b/maybraid/chico/groves/src/date_grove.rs
@@ -1,4 +1,4 @@
-//! Date Grove — moderate-density cultivated Date Palm upper-canopy grove
+//! Date Grove — high-density cultivated Date Palm upper-canopy grove
 //! ([RFC-183 §3.4.7.9], [#357](https://github.com/ramate-io/maybraid/issues/357)).
 //!
 //! Single moderate-crown date palm form with tight cell offset on warm flat terrain.
@@ -22,14 +22,14 @@ const MODERATE_CROWN_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
 
 /// Authored Date Grove definition.
 ///
-/// Cell footprint sits at the RFC midpoint (`12.0` m). Offset stays tight so placements read as
-/// cultivated rows.
+/// Cell footprint sits at the RFC midpoint (`12.0` m). Placements stay on cell centroids with only
+/// ±`0.5` m horizontal jitter for regular palm rows.
 pub fn definition() -> GroveDefinition<DateGroveCell> {
 	GroveDefinition {
 		cell_extent_xz: Vec2::splat(12.0),
 		placement: GrovePlacementRanges::new(
-			UnitRange::new(0.85, 1.15),
-			UnitRange::new(-2.0, 2.0),
+			UnitRange::new(1.0, 1.0),
+			UnitRange::new(-0.5, 0.5),
 		),
 		distribution: DateGroveCell::distribution(),
 	}
@@ -70,17 +70,21 @@ const DATE_PALM_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
 	PaletteSlot::new("fresh_green", "yellow_green"),
 ]);
 
+/// Explicit `None` weight so ~`95%` of cells receive a palm (`0.05` empty vs `0.95` placed).
+const CULTIVATED_EMPTY_WEIGHT: f32 = 0.05;
+const CULTIVATED_PLACED_WEIGHT: f32 = 0.95;
+
 impl DateGroveCell {
 	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
 	///
-	/// Placed weight `1.0`; the `None` weight of `2.4` puts the placed share at
-	/// `1.0 / 3.4 ≈ 0.29`, mid RFC `DENSITY_RANGE` (`0.22..0.42`).
+	/// `None` weight `0.05` against placed weight `0.95` yields a `0.95` placed share for
+	/// regular grove planting.
 	pub fn distribution() -> GroveDistribution<Self> {
 		let fruiting_date =
-			PlacementConstraints::new(UnitRange::new(0.0, 0.46), UnitRange::new(0.0, 0.30));
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.30));
 		GroveDistribution::new(vec![
-			GroveBucket::none(2.4),
-			GroveBucket::placed(1.0, fruiting_date, Self::FruitingDatePalm),
+			GroveBucket::none(CULTIVATED_EMPTY_WEIGHT),
+			GroveBucket::placed(CULTIVATED_PLACED_WEIGHT, fruiting_date, Self::FruitingDatePalm),
 		])
 	}
 
@@ -111,19 +115,30 @@ mod tests {
 		let dist = DateGroveCell::distribution();
 		assert_eq!(dist.len(), 2);
 		assert!(dist.buckets[0].item.is_none());
-		assert_eq!(dist.buckets[0].weight, 2.4);
+		assert_eq!(dist.buckets[0].weight, CULTIVATED_EMPTY_WEIGHT);
 		assert_eq!(dist.buckets[1].item, Some(DateGroveCell::FruitingDatePalm));
-		assert_eq!(dist.buckets[1].weight, 1.0);
+		assert_eq!(dist.buckets[1].weight, CULTIVATED_PLACED_WEIGHT);
 		Ok(())
 	}
 
 	#[test]
-	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+	fn placed_share_targets_cultivated_fill() -> Result<()> {
 		let dist = DateGroveCell::distribution();
 		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
 		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
 		let share = placed / total;
-		assert!((0.22..=0.42).contains(&share), "placed share {share} outside RFC density");
+		assert!(
+			(0.94..=0.96).contains(&share),
+			"placed share {share} outside cultivated ~95% target"
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn placement_uses_tight_centroid_offset_and_uniform_scale() -> Result<()> {
+		let def = definition();
+		assert_eq!(def.placement.offset, UnitRange::new(-0.5, 0.5));
+		assert_eq!(def.placement.scale, UnitRange::new(1.0, 1.0));
 		Ok(())
 	}
 
@@ -138,7 +153,7 @@ mod tests {
 	}
 
 	#[test]
-	fn placement_constraints_match_rfc() -> Result<()> {
+	fn placement_constraints_use_full_elevation_and_rfc_steepness() -> Result<()> {
 		let dist = DateGroveCell::distribution();
 		let palm = dist
 			.buckets
@@ -146,7 +161,7 @@ mod tests {
 			.find(|b| b.item == Some(DateGroveCell::FruitingDatePalm))
 			.ok_or_else(|| anyhow::anyhow!("missing fruiting date palm bucket"))?;
 		assert_eq!(palm.constraints.elevation.start, 0.0);
-		assert_eq!(palm.constraints.elevation.end, 0.46);
+		assert_eq!(palm.constraints.elevation.end, 1.0);
 		assert_eq!(palm.constraints.steepness.end, 0.30);
 		Ok(())
 	}

--- a/maybraid/chico/groves/src/date_grove.rs
+++ b/maybraid/chico/groves/src/date_grove.rs
@@ -1,0 +1,183 @@
+//! Date Grove — moderate-density cultivated Date Palm upper-canopy grove
+//! ([RFC-183 §3.4.7.9], [#357](https://github.com/ramate-io/maybraid/issues/357)).
+//!
+//! Single moderate-crown date palm form with tight cell offset on warm flat terrain.
+//! Forest-layer attachment remains a follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{DateGrove, DateGroveStd};
+
+/// Moderate sampled crown-density band ([`0.35`, `0.65`]).
+const MODERATE_CROWN_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
+
+/// Authored Date Grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`12.0` m). Offset stays tight so placements read as
+/// cultivated rows.
+pub fn definition() -> GroveDefinition<DateGroveCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(12.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-2.0, 2.0),
+		),
+		distribution: DateGroveCell::distribution(),
+	}
+}
+
+/// Ordered date-grove varietals ([RFC-183 §3.4.7.9]); the explicit `None` bucket lives only in the
+/// distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateGroveCell {
+	FruitingDatePalm,
+}
+
+/// Typed authored geometry for one date-grove varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DateGroveItem {
+	DatePalm(&'static DateGroveDatePalm),
+}
+
+/// Authored geometry ranges for one Date Palm form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DateGroveDatePalm {
+	pub height: UnitRange,
+	pub crown_density: UnitRange,
+}
+
+const FRUITING_DATE_PALM: DateGroveDatePalm = DateGroveDatePalm {
+	height: UnitRange::new(5.0, 8.0),
+	crown_density: MODERATE_CROWN_DENSITY,
+};
+
+const DATE_PALM_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("palm_bark", "tan_bark"),
+	PaletteSlot::new("date_trunk", "dry_brown"),
+]);
+
+const DATE_PALM_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("palm_green", "olive_green"),
+	PaletteSlot::new("fresh_green", "yellow_green"),
+]);
+
+impl DateGroveCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weight `1.0`; the `None` weight of `2.4` puts the placed share at
+	/// `1.0 / 3.4 ≈ 0.29`, mid RFC `DENSITY_RANGE` (`0.22..0.42`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let fruiting_date =
+			PlacementConstraints::new(UnitRange::new(0.0, 0.46), UnitRange::new(0.0, 0.30));
+		GroveDistribution::new(vec![
+			GroveBucket::none(2.4),
+			GroveBucket::placed(1.0, fruiting_date, Self::FruitingDatePalm),
+		])
+	}
+
+	pub fn item(self) -> DateGroveItem {
+		match self {
+			Self::FruitingDatePalm => DateGroveItem::DatePalm(&FRUITING_DATE_PALM),
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		DATE_PALM_STICK_MIX
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		DATE_PALM_CANOPY_MIX
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{FlatTerrainSample, ForestGroveBiases, Grove, GroveExtent};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = DateGroveCell::distribution();
+		assert_eq!(dist.len(), 2);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 2.4);
+		assert_eq!(dist.buckets[1].item, Some(DateGroveCell::FruitingDatePalm));
+		assert_eq!(dist.buckets[1].weight, 1.0);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = DateGroveCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.22..=0.42).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let DateGroveItem::DatePalm(palm) = DateGroveCell::FruitingDatePalm.item() else {
+			anyhow::bail!("expected fruiting date palm item");
+		};
+		assert_eq!(palm.height, UnitRange::new(5.0, 8.0));
+		assert_eq!(palm.crown_density, MODERATE_CROWN_DENSITY);
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_match_rfc() -> Result<()> {
+		let dist = DateGroveCell::distribution();
+		let palm = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(DateGroveCell::FruitingDatePalm))
+			.ok_or_else(|| anyhow::anyhow!("missing fruiting date palm bucket"))?;
+		assert_eq!(palm.constraints.elevation.start, 0.0);
+		assert_eq!(palm.constraints.elevation.end, 0.46);
+		assert_eq!(palm.constraints.steepness.end, 0.30);
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [DateGroveCell::FruitingDatePalm] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(120.0, 1.0, 120.0));
+		let terrain = FlatTerrainSample { elevation: 0.30, steepness: 0.10 };
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/date_grove/render.rs
+++ b/maybraid/chico/groves/src/date_grove/render.rs
@@ -1,0 +1,315 @@
+//! [`RenderItem`] for populated Date Grove groves ([#357](https://github.com/ramate-io/maybraid/issues/357)).
+//!
+//! Date Palm geometry build follows [`crate::palm_shade::render`] shade-date logic.
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::DatePalmSbs;
+use chico_sbs_trees::date_palm::DatePalm;
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::date_grove::{definition, DateGroveCell, DateGroveDatePalm, DateGroveItem};
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::skipped_mesh_material::{SkippedLeafMeshMaterial, SkippedStickMeshMaterial};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Date Grove instance.
+pub type DateGroveStd = DateGrove<
+	ChicoStickMaterial,
+	SkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Date Grove preview (moderate cultivated date palm forms).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct DateGrove<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<DateGroveCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for DateGrove<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> DateGrove<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<DateGroveCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<DateGroveCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: procedural_common::UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+impl BuildWithNoise<DatePalmSbs> for DateGroveDatePalm {
+	fn build_with_noise(&self, noise: NoiseParams) -> DatePalmSbs {
+		let config = NoiseConfig::new(noise);
+		let height = sample_f32(&config, self.height, 1.0)
+			.max(self.height.start.min(self.height.end));
+		let crown_density = sample_f32(&config, self.crown_density, 2.0);
+
+		let mut geometry = DatePalmSbs::default();
+		geometry.scale.stalk_height = height;
+		geometry.crown.ring_count = 3 + (crown_density * 3.0).round() as u32;
+		geometry.crown.fronds_per_ring = 6 + (crown_density * 6.0).round() as u32;
+		geometry.frond_world_scale = 0.35 + crown_density * 0.35;
+		geometry.crown_tuft_scale_factor = 0.04 + crown_density * 0.02;
+		geometry.trunk_noise = noise;
+		geometry
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for DateGrove<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let DateGroveItem::DatePalm(palm) = placed.variant.item();
+			let geometry = palm.build_with_noise(build_noise);
+			let mut tree = DatePalm::<StickM, StickS, LeafM, LeafS>::default();
+			tree.geometry = geometry;
+			tree.stick_material = self.stick_material.clone();
+			tree.leaf_material = self.leaf_material.clone();
+			tree.stick_surface_noise = placement_noise(self.stick_surface_noise, placed.position);
+			tree.foliage_noise = foliage_noise;
+			let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+			patch_spawned_leaf_material::<StickM>(
+				&entities,
+				placed.variant.stick_palette_mix(),
+				stick_seed,
+				commands,
+			);
+			patch_spawned_leaf_material::<LeafM>(
+				&entities,
+				placed.variant.canopy_palette_mix(),
+				canopy_seed,
+				commands,
+			);
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn palm_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let DateGroveItem::DatePalm(palm) = DateGroveCell::FruitingDatePalm.item() else {
+			anyhow::bail!("expected fruiting date palm item");
+		};
+		let palm_geom = palm.build_with_noise(noise);
+		assert!(palm_geom.scale.stalk_height >= palm.height.start.min(palm.height.end));
+		assert!(palm_geom.scale.stalk_height <= palm.height.start.max(palm.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [DateGroveCell::FruitingDatePalm] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn with_resolved_placements_skips_live_selection() -> Result<()> {
+		let placement =
+			GrovePlacedCell::new(DateGroveCell::FruitingDatePalm, Vec3::new(1.0, 0.0, 2.0), 1.0);
+		let item = DateGroveStd::with_resolved_placements(
+			vec![placement.clone()],
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			SkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements(), vec![placement]);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/dryland.rs
+++ b/maybraid/chico/groves/src/dryland.rs
@@ -75,7 +75,7 @@ const DRYLAND_LIAMS: DrylandLiamsConifer = DrylandLiamsConifer {
 
 const DRYLAND_VASE: DrylandVaseTree = DrylandVaseTree {
 	height: UnitRange::new(10.0, 20.0),
-	stalk_radius: UnitRange::new(0.25, 0.50),
+	stalk_radius: UnitRange::new(0.34, 0.68),
 	canopy_spread: UnitRange::new(2.0, 5.5),
 	canopy_density: SPARSE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/groves/src/forlorn_savanna.rs
+++ b/maybraid/chico/groves/src/forlorn_savanna.rs
@@ -1,0 +1,331 @@
+//! Forlorn Savanna — low-density sparse dry upper-canopy grove
+//! ([RFC-183 §3.4.7.6], [#351](https://github.com/ramate-io/maybraid/issues/351)).
+//!
+//! Wind-shaped Rory's Head-trained forms, acacia-impression High Bush, and rare dry Storybook
+//! accents across open savanna. Forest-layer attachment remains a follow-up.
+
+use std::ops::RangeInclusive;
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{ForlornSavanna, ForlornSavannaStd};
+
+/// Sparse sampled canopy-density band ([`0.0`, `0.35`]).
+const SPARSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.0, 0.35);
+/// Flat sparse crown projection for acacia-like High Bush forms.
+const SPARSE_PROJECTION_RADIAL: UnitRange = UnitRange::new(0.42, 0.62);
+const SPARSE_PROJECTION_VERTICAL: UnitRange = UnitRange::new(0.32, 0.52);
+
+/// Authored Forlorn Savanna grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`30` m). The offset range is signed and ± one cell so
+/// placements break the underlying grid instead of clustering near cell centers.
+pub fn definition() -> GroveDefinition<ForlornSavannaCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(30.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-30.0, 30.0),
+		),
+		distribution: ForlornSavannaCell::distribution(),
+	}
+}
+
+/// Ordered forlorn-savanna varietals ([RFC-183 §3.4.7.6]); the explicit `None` bucket lives only in
+/// the distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForlornSavannaCell {
+	SavannaRory,
+	AcaciaHighBush,
+	RareSavannaStorybook,
+}
+
+/// Typed authored geometry for one forlorn-savanna varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ForlornSavannaItem {
+	Rory(&'static ForlornSavannaRory),
+	HighBush(&'static ForlornSavannaHighBush),
+	Storybook(&'static ForlornSavannaStorybook),
+}
+
+/// Authored geometry ranges for one Rory's Head-trained form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForlornSavannaRory {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one acacia-impression Common High Bush form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForlornSavannaHighBush {
+	pub height: UnitRange,
+	pub shoot_count: RangeInclusive<u32>,
+	pub branch_depth: RangeInclusive<u32>,
+	pub radial_strength: UnitRange,
+	pub vertical_bias: UnitRange,
+	/// Terminal foliage radius in **world meters** (render converts to a height fraction).
+	pub leaf_radius: UnitRange,
+}
+
+/// Authored geometry ranges for one dry Storybook Tree form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForlornSavannaStorybook {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const SAVANNA_RORY: ForlornSavannaRory = ForlornSavannaRory {
+	height: UnitRange::new(5.0, 30.0),
+	stalk_radius: UnitRange::new(0.12, 0.45),
+	canopy_spread: UnitRange::new(3.0, 12.0),
+	canopy_density: SPARSE_CANOPY_DENSITY,
+};
+
+const ACACIA_HIGH_BUSH: ForlornSavannaHighBush = ForlornSavannaHighBush {
+	height: UnitRange::new(5.0, 10.0),
+	shoot_count: 4..=12,
+	branch_depth: 2..=3,
+	radial_strength: SPARSE_PROJECTION_RADIAL,
+	vertical_bias: SPARSE_PROJECTION_VERTICAL,
+	leaf_radius: UnitRange::new(0.35, 0.55),
+};
+
+const RARE_SAVANNA_STORYBOOK: ForlornSavannaStorybook = ForlornSavannaStorybook {
+	height: UnitRange::new(10.0, 20.0),
+	stalk_radius: UnitRange::new(0.16, 0.38),
+	canopy_spread: UnitRange::new(2.5, 6.5),
+	canopy_density: SPARSE_CANOPY_DENSITY,
+};
+
+const SAVANNA_RORY_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("weathered_bark", "dark_bark"),
+	PaletteSlot::new("red_brown", "gray_brown"),
+]);
+
+const SAVANNA_RORY_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("olive_green", "dry_green"),
+	PaletteSlot::new("yellow_green", "dusty_green"),
+]);
+
+const ACACIA_HIGH_BUSH_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("acacia_bark", "red_brown"),
+	PaletteSlot::new("tan_bark", "gray_brown"),
+]);
+
+const ACACIA_HIGH_BUSH_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("dusty_green", "olive_green"),
+	PaletteSlot::new("yellow_green", "dry_green"),
+]);
+
+const SAVANNA_STORYBOOK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("dry_brown", "dark_bark"),
+	PaletteSlot::new("gray_brown", "tan_bark"),
+]);
+
+const SAVANNA_STORYBOOK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("olive_green", "yellow_green"),
+	PaletteSlot::new("dusty_green", "light_green"),
+]);
+
+impl ForlornSavannaCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `4.35`; the `None` weight of `22.0` puts the placed share at
+	/// `4.35 / 26.35 ≈ 0.17`, mid RFC `DENSITY_RANGE` (`0.06..0.20`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let rory =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.58));
+		let high_bush =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.64));
+		let storybook =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.50));
+		GroveDistribution::new(vec![
+			GroveBucket::none(22.0),
+			GroveBucket::placed(2.0, rory, Self::SavannaRory),
+			GroveBucket::placed(2.0, high_bush, Self::AcaciaHighBush),
+			GroveBucket::placed(0.35, storybook, Self::RareSavannaStorybook),
+		])
+	}
+
+	pub fn item(self) -> ForlornSavannaItem {
+		match self {
+			Self::SavannaRory => ForlornSavannaItem::Rory(&SAVANNA_RORY),
+			Self::AcaciaHighBush => ForlornSavannaItem::HighBush(&ACACIA_HIGH_BUSH),
+			Self::RareSavannaStorybook => ForlornSavannaItem::Storybook(&RARE_SAVANNA_STORYBOOK),
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::SavannaRory => SAVANNA_RORY_STICK_MIX,
+			Self::AcaciaHighBush => ACACIA_HIGH_BUSH_STICK_MIX,
+			Self::RareSavannaStorybook => SAVANNA_STORYBOOK_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::SavannaRory => SAVANNA_RORY_CANOPY_MIX,
+			Self::AcaciaHighBush => ACACIA_HIGH_BUSH_CANOPY_MIX,
+			Self::RareSavannaStorybook => SAVANNA_STORYBOOK_CANOPY_MIX,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveCellOutcome, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+	use procedural_common::NoiseParams;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = ForlornSavannaCell::distribution();
+		assert_eq!(dist.len(), 4);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 22.0);
+		assert_eq!(dist.buckets[1].item, Some(ForlornSavannaCell::SavannaRory));
+		assert_eq!(dist.buckets[1].weight, 2.0);
+		assert_eq!(dist.buckets[2].item, Some(ForlornSavannaCell::AcaciaHighBush));
+		assert_eq!(dist.buckets[2].weight, 2.0);
+		assert_eq!(dist.buckets[3].item, Some(ForlornSavannaCell::RareSavannaStorybook));
+		assert_eq!(dist.buckets[3].weight, 0.35);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = ForlornSavannaCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.06..=0.20).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let ForlornSavannaItem::Rory(rory) = ForlornSavannaCell::SavannaRory.item() else {
+			anyhow::bail!("expected rory item");
+		};
+		assert_eq!(rory.height, UnitRange::new(5.0, 30.0));
+		assert_eq!(rory.canopy_spread, UnitRange::new(3.0, 12.0));
+		assert_eq!(rory.canopy_density, SPARSE_CANOPY_DENSITY);
+
+		let ForlornSavannaItem::HighBush(bush) = ForlornSavannaCell::AcaciaHighBush.item() else {
+			anyhow::bail!("expected high bush item");
+		};
+		assert_eq!(bush.height, UnitRange::new(5.0, 10.0));
+
+		let ForlornSavannaItem::Storybook(story) = ForlornSavannaCell::RareSavannaStorybook.item()
+		else {
+			anyhow::bail!("expected storybook item");
+		};
+		assert_eq!(story.height, UnitRange::new(10.0, 20.0));
+		assert_eq!(story.canopy_density, SPARSE_CANOPY_DENSITY);
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_match_rfc() -> Result<()> {
+		let dist = ForlornSavannaCell::distribution();
+		let rory = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(ForlornSavannaCell::SavannaRory))
+			.ok_or_else(|| anyhow::anyhow!("missing rory bucket"))?;
+		assert_eq!(rory.constraints.elevation.start, 0.0);
+		assert_eq!(rory.constraints.elevation.end, 1.0);
+		assert_eq!(rory.constraints.steepness.end, 0.58);
+
+		let high_bush = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(ForlornSavannaCell::AcaciaHighBush))
+			.ok_or_else(|| anyhow::anyhow!("missing high bush bucket"))?;
+		assert_eq!(high_bush.constraints.elevation.end, 1.0);
+		assert_eq!(high_bush.constraints.steepness.end, 0.64);
+
+		let storybook = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(ForlornSavannaCell::RareSavannaStorybook))
+			.ok_or_else(|| anyhow::anyhow!("missing storybook bucket"))?;
+		assert_eq!(storybook.constraints.elevation.start, 0.0);
+		assert_eq!(storybook.constraints.steepness.end, 0.50);
+		Ok(())
+	}
+
+	#[test]
+	fn steep_slope_rejects_rory_but_allows_high_bush() -> Result<()> {
+		let prepared =
+			ForlornSavannaCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
+		let terrain = FlatTerrainSample { elevation: 0.40, steepness: 0.60 };
+		let bush_outcome = prepared.select_from(5, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
+		match bush_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_eq!(variant, ForlornSavannaCell::AcaciaHighBush);
+			}
+			other => anyhow::bail!("expected AcaciaHighBush on moderate slope, got {other:?}"),
+		}
+		let rory_outcome = prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
+		match rory_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_ne!(variant, ForlornSavannaCell::SavannaRory);
+			}
+			GroveCellOutcome::Empty { .. } | GroveCellOutcome::Rejected { .. } => {}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			ForlornSavannaCell::SavannaRory,
+			ForlornSavannaCell::AcaciaHighBush,
+			ForlornSavannaCell::RareSavannaStorybook,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(300.0, 1.0, 300.0));
+		let terrain = FlatTerrainSample { elevation: 0.40, steepness: 0.20 };
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/forlorn_savanna.rs
+++ b/maybraid/chico/groves/src/forlorn_savanna.rs
@@ -105,7 +105,7 @@ const ACACIA_HIGH_BUSH: ForlornSavannaHighBush = ForlornSavannaHighBush {
 
 const RARE_SAVANNA_STORYBOOK: ForlornSavannaStorybook = ForlornSavannaStorybook {
 	height: UnitRange::new(10.0, 20.0),
-	stalk_radius: UnitRange::new(0.16, 0.38),
+	stalk_radius: UnitRange::new(0.24, 0.52),
 	canopy_spread: UnitRange::new(2.5, 6.5),
 	canopy_density: SPARSE_CANOPY_DENSITY,
 };
@@ -143,20 +143,19 @@ const SAVANNA_STORYBOOK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
 impl ForlornSavannaCell {
 	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
 	///
-	/// Placed weights total `4.35`; the `None` weight of `22.0` puts the placed share at
-	/// `4.35 / 26.35 ≈ 0.17`, mid RFC `DENSITY_RANGE` (`0.06..0.20`).
+	/// Placed weights total `5.2`; the `None` weight of `30.0` puts the placed share at
+	/// `5.2 / 35.2 ≈ 0.15`, mid RFC `DENSITY_RANGE` (`0.06..0.20`).
 	pub fn distribution() -> GroveDistribution<Self> {
-		let rory =
-			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.58));
+		let rory = PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.58));
 		let high_bush =
 			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.64));
 		let storybook =
 			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.50));
 		GroveDistribution::new(vec![
-			GroveBucket::none(22.0),
-			GroveBucket::placed(2.0, rory, Self::SavannaRory),
+			GroveBucket::none(30.0),
+			GroveBucket::placed(3.0, rory, Self::SavannaRory),
 			GroveBucket::placed(2.0, high_bush, Self::AcaciaHighBush),
-			GroveBucket::placed(0.35, storybook, Self::RareSavannaStorybook),
+			GroveBucket::placed(0.2, storybook, Self::RareSavannaStorybook),
 		])
 	}
 
@@ -200,13 +199,13 @@ mod tests {
 		let dist = ForlornSavannaCell::distribution();
 		assert_eq!(dist.len(), 4);
 		assert!(dist.buckets[0].item.is_none());
-		assert_eq!(dist.buckets[0].weight, 22.0);
+		assert_eq!(dist.buckets[0].weight, 30.0);
 		assert_eq!(dist.buckets[1].item, Some(ForlornSavannaCell::SavannaRory));
-		assert_eq!(dist.buckets[1].weight, 2.0);
+		assert_eq!(dist.buckets[1].weight, 3.0);
 		assert_eq!(dist.buckets[2].item, Some(ForlornSavannaCell::AcaciaHighBush));
 		assert_eq!(dist.buckets[2].weight, 2.0);
 		assert_eq!(dist.buckets[3].item, Some(ForlornSavannaCell::RareSavannaStorybook));
-		assert_eq!(dist.buckets[3].weight, 0.35);
+		assert_eq!(dist.buckets[3].weight, 0.2);
 		Ok(())
 	}
 
@@ -275,8 +274,12 @@ mod tests {
 
 	#[test]
 	fn steep_slope_rejects_rory_but_allows_high_bush() -> Result<()> {
-		let prepared =
-			ForlornSavannaCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
+		let prepared = ForlornSavannaCell::distribution().prepare(
+			0.0,
+			0.0,
+			NoiseParams::default(),
+			Vec3::ZERO,
+		);
 		let terrain = FlatTerrainSample { elevation: 0.40, steepness: 0.60 };
 		let bush_outcome = prepared.select_from(5, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
 		match bush_outcome {

--- a/maybraid/chico/groves/src/forlorn_savanna/render.rs
+++ b/maybraid/chico/groves/src/forlorn_savanna/render.rs
@@ -1,0 +1,470 @@
+//! [`RenderItem`] for populated Forlorn Savanna groves ([#351](https://github.com/ramate-io/maybraid/issues/351)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::anchors::high_bush::{
+	DEFAULT_ANCHOR_LIFT_FRACTION, DEFAULT_SEGMENT_LENGTH_FRACTION_HI,
+	DEFAULT_SEGMENT_LENGTH_FRACTION_LO, DEFAULT_SEGMENT_RADIUS_FRACTION_HI,
+	DEFAULT_SEGMENT_RADIUS_FRACTION_LO,
+};
+use chico_sbs_geometry::{RorysHeadTrainedSbs, StorybookTreeSbs};
+use chico_sbs_trees::rorys_head_trained::RorysHeadTrained;
+use chico_sbs_trees::storybook_tree::StorybookTree;
+use chico_tree_components::{HighBushFoliageStyle, HighBushShoots, HighBushShootsShape};
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::forlorn_savanna::{
+	definition, ForlornSavannaCell, ForlornSavannaHighBush, ForlornSavannaItem, ForlornSavannaRory,
+	ForlornSavannaStorybook,
+};
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Forlorn Savanna instance.
+pub type ForlornSavannaStd = ForlornSavanna<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Forlorn Savanna grove preview (sparse dry rory, acacia bush, and storybook forms).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct ForlornSavanna<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<ForlornSavannaCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for ForlornSavanna<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> ForlornSavanna<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<ForlornSavannaCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<ForlornSavannaCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+fn span_fraction(canopy_spread: f32, height: f32) -> f32 {
+	(canopy_spread / height.max(0.5)).clamp(0.35, 1.20)
+}
+
+impl BuildWithNoise<RorysHeadTrainedSbs> for ForlornSavannaRory {
+	fn build_with_noise(&self, noise: NoiseParams) -> RorysHeadTrainedSbs {
+		let config = NoiseConfig::new(noise);
+		let height = sample_f32(&config, self.height, 1.0).max(0.75);
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+
+		let mut geometry = RorysHeadTrainedSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.canopy_noise = noise;
+		let span = span_fraction(canopy_spread, height);
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.95, span * 1.15);
+		geometry
+	}
+}
+
+impl BuildWithNoise<HighBushShootsShape> for ForlornSavannaHighBush {
+	fn build_with_noise(&self, noise: NoiseParams) -> HighBushShootsShape {
+		let config = NoiseConfig::new(noise);
+		let sample_u32 = |range: &std::ops::RangeInclusive<u32>, salt| {
+			let lo = *range.start() as usize;
+			let hi = (*range.end() as usize).saturating_add(1);
+			config.sample_range_usize_4d(lo, hi, 0.0, 0.0, 0.0, salt) as u32
+		};
+
+		let height = sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let leaf_radius = sample_f32(&config, self.leaf_radius, 2.0).max(0.01);
+
+		HighBushShootsShape {
+			height,
+			anchor_lift_fraction: DEFAULT_ANCHOR_LIFT_FRACTION,
+			shoot_count: sample_u32(&self.shoot_count, 3.0),
+			radial_strength: sample_f32(&config, self.radial_strength, 5.0),
+			vertical_bias: sample_f32(&config, self.vertical_bias, 6.0),
+			branch_depth: sample_u32(&self.branch_depth, 4.0) as usize,
+			segment_length_fraction_lo: DEFAULT_SEGMENT_LENGTH_FRACTION_LO,
+			segment_length_fraction_hi: DEFAULT_SEGMENT_LENGTH_FRACTION_HI,
+			segment_radius_fraction_lo: DEFAULT_SEGMENT_RADIUS_FRACTION_LO,
+			segment_radius_fraction_hi: DEFAULT_SEGMENT_RADIUS_FRACTION_HI,
+			leaf_radius_fraction: leaf_radius / height,
+			foliage_style: HighBushFoliageStyle::PlaneSplay,
+			chain_noise: noise,
+		}
+	}
+}
+
+impl BuildWithNoise<StorybookTreeSbs> for ForlornSavannaStorybook {
+	fn build_with_noise(&self, noise: NoiseParams) -> StorybookTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 4.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = StorybookTreeSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.05);
+		geometry.rings.height_range = UnitRange::new(0.58, 1.0);
+		geometry.canopy_noise = noise;
+		let _ = canopy_density;
+		geometry
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for ForlornSavanna<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let entities = match placed.variant.item() {
+				ForlornSavannaItem::Rory(rory) => {
+					let geometry = rory.build_with_noise(build_noise);
+					let mut tree = RorysHeadTrained::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				ForlornSavannaItem::HighBush(bush) => {
+					let mut shape = bush.build_with_noise(build_noise);
+					shape.chain_noise = chain_noise;
+					let entities = HighBushShoots::<StickM, StickS, LeafM, LeafS>::spawn_from_shape(
+						shape,
+						self.stick_surface_noise,
+						self.leaf_surface_noise,
+						self.stick_material.clone(),
+						self.leaf_material.clone(),
+						commands,
+						cascade_chunk,
+						local,
+					);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				ForlornSavannaItem::Storybook(story) => {
+					let geometry = story.build_with_noise(build_noise);
+					let mut tree = StorybookTree::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+			};
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let ForlornSavannaItem::Rory(rory) = ForlornSavannaCell::SavannaRory.item() else {
+			anyhow::bail!("expected rory item");
+		};
+		let rory_geom = rory.build_with_noise(noise);
+		assert!(rory_geom.scale.tree_height >= rory.height.start.min(rory.height.end));
+		assert!(rory_geom.scale.tree_height <= rory.height.start.max(rory.height.end));
+
+		let ForlornSavannaItem::HighBush(bush) = ForlornSavannaCell::AcaciaHighBush.item() else {
+			anyhow::bail!("expected high bush item");
+		};
+		let shape = bush.build_with_noise(noise);
+		assert!(shape.height >= bush.height.start.min(bush.height.end));
+		assert_eq!(shape.foliage_style, HighBushFoliageStyle::PlaneSplay);
+
+		let ForlornSavannaItem::Storybook(story) = ForlornSavannaCell::RareSavannaStorybook.item()
+		else {
+			anyhow::bail!("expected storybook item");
+		};
+		let story_geom = story.build_with_noise(noise);
+		assert!(story_geom.scale.tree_height >= story.height.start.min(story.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			ForlornSavannaCell::SavannaRory,
+			ForlornSavannaCell::AcaciaHighBush,
+			ForlornSavannaCell::RareSavannaStorybook,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn with_resolved_placements_skips_live_selection() -> Result<()> {
+		let placement =
+			GrovePlacedCell::new(ForlornSavannaCell::SavannaRory, Vec3::new(1.0, 0.0, 2.0), 1.0);
+		let item = ForlornSavannaStd::with_resolved_placements(
+			vec![placement.clone()],
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			GroveSkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements(), vec![placement]);
+		Ok(())
+	}
+
+	#[test]
+	fn default_weights_yield_low_density_placements_in_preview_grid() -> Result<()> {
+		let span = DEFAULT_GROVE_EXTENT_XZ;
+		let grove = ForlornSavannaStd::default()
+			.with_terrain(FlatTerrainSample { elevation: 0.40, steepness: 0.20 })
+			.with_extent(GroveExtent::new(Vec3::ZERO, Vec3::new(span, 1.0, span)));
+		let cells = grove.placement_cells().len();
+		let placements = grove.placements();
+		let placed_share = placements.len() as f32 / cells as f32;
+		assert!(
+			(0.06..=0.20).contains(&placed_share),
+			"expected forlorn-savanna fill, got {placed_share} ({}/{cells})",
+			placements.len()
+		);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/goettingen_follow.rs
+++ b/maybraid/chico/groves/src/goettingen_follow.rs
@@ -93,7 +93,7 @@ const OLD_GROWTH_FOLLOW_BRAID_OAK: GoettingenFollowBraidOak = GoettingenFollowBr
 
 const FOLLOW_STORYBOOK: GoettingenFollowStorybook = GoettingenFollowStorybook {
 	height: UnitRange::new(4.0, 9.0),
-	stalk_radius: UnitRange::new(0.12, 0.28),
+	stalk_radius: UnitRange::new(0.18, 0.40),
 	canopy_spread: UnitRange::new(1.6, 4.0),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/groves/src/grove/palette.rs
+++ b/maybraid/chico/groves/src/grove/palette.rs
@@ -209,6 +209,9 @@ pub fn resolve_palette_color(name: &str) -> Option<Color> {
 		"acacia_bark" => Color::srgb(0.55, 0.42, 0.28),
 		"dry_banyan_bark" => Color::srgb(0.48, 0.38, 0.28),
 		"willow_bark" => Color::srgb(0.42, 0.34, 0.24),
+		"orchard_bark" => Color::srgb(0.56, 0.42, 0.28),
+		"pale_blossom" => Color::srgb(0.92, 0.82, 0.86),
+		"grape_green" => Color::srgb(0.32, 0.52, 0.28),
 		_ => return None,
 	})
 }

--- a/maybraid/chico/groves/src/grove/palette.rs
+++ b/maybraid/chico/groves/src/grove/palette.rs
@@ -156,6 +156,7 @@ pub fn resolve_palette_color(name: &str) -> Option<Color> {
 		"wind_barked" => Color::srgb(0.42, 0.38, 0.32),
 		"stone_gray" => Color::srgb(0.48, 0.46, 0.44),
 		"cold_green" => Color::srgb(0.16, 0.38, 0.32),
+		"christmas_green" => Color::srgb(0.14, 0.42, 0.22),
 		"dry_conifer_bark" => Color::srgb(0.42, 0.34, 0.24),
 		"sun_baked_bark" => Color::srgb(0.62, 0.52, 0.38),
 		"sage_green" => Color::srgb(0.42, 0.48, 0.32),
@@ -207,6 +208,7 @@ pub fn resolve_palette_color(name: &str) -> Option<Color> {
 		"deep_blue_green" => Color::srgb(0.12, 0.38, 0.42),
 		"acacia_bark" => Color::srgb(0.55, 0.42, 0.28),
 		"dry_banyan_bark" => Color::srgb(0.48, 0.38, 0.28),
+		"willow_bark" => Color::srgb(0.42, 0.34, 0.24),
 		_ => return None,
 	})
 }

--- a/maybraid/chico/groves/src/leeward.rs
+++ b/maybraid/chico/groves/src/leeward.rs
@@ -30,7 +30,7 @@ const DENSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.50, 0.85);
 /// placements break the underlying grid instead of clustering near cell centers.
 pub fn definition() -> GroveDefinition<LeewardCell> {
 	GroveDefinition {
-		cell_extent_xz: Vec2::splat(9.0),
+		cell_extent_xz: Vec2::splat(19.0),
 		placement: GrovePlacementRanges::new(
 			UnitRange::new(0.85, 1.15),
 			UnitRange::new(-19.0, 19.0),

--- a/maybraid/chico/groves/src/leeward.rs
+++ b/maybraid/chico/groves/src/leeward.rs
@@ -84,14 +84,14 @@ const WINDBREAK_TEMPERATE_CONIFER: LeewardTemperateConifer = LeewardTemperateCon
 
 const ROUNDED_LEEWARD_STORYBOOK: LeewardStorybook = LeewardStorybook {
 	height: UnitRange::new(10.0, 18.0),
-	stalk_radius: UnitRange::new(0.16, 0.34),
+	stalk_radius: UnitRange::new(0.22, 0.46),
 	canopy_spread: UnitRange::new(2.5, 6.0),
 	canopy_density: DENSE_CANOPY_DENSITY,
 };
 
 const HIGH_LEEWARD_STORYBOOK: LeewardStorybook = LeewardStorybook {
 	height: UnitRange::new(16.0, 24.0),
-	stalk_radius: UnitRange::new(0.18, 0.40),
+	stalk_radius: UnitRange::new(0.26, 0.52),
 	canopy_spread: UnitRange::new(3.0, 7.5),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -13,6 +13,12 @@ pub mod trade_winds;
 pub mod wandering_acacia;
 pub mod leeward;
 pub mod christmas_taiga;
+pub mod conifer_massives;
+pub mod temperate_massives;
+pub mod riparian_general;
+pub mod rolling_oaks;
+pub mod forlorn_savanna;
+pub mod orchard;
 pub mod conifer_sapling;
 pub mod goettingen_follow;
 pub mod high_bush;
@@ -76,6 +82,26 @@ pub use leeward::{
 pub use christmas_taiga::{
 	ChristmasTaigaCell, ChristmasTaigaItem, ChristmasTaigaNorthernConifer,
 };
+pub use conifer_massives::{
+	ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
+	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
+};
+pub use temperate_massives::{
+	TemperateMassivesBraidOak, TemperateMassivesCell, TemperateMassivesItem, TemperateMassivesRory,
+	TemperateMassivesStorybook,
+};
+pub use riparian_general::{
+	RiparianGeneralBraidOak, RiparianGeneralCell, RiparianGeneralHighBush, RiparianGeneralItem,
+	RiparianGeneralStorybook,
+};
+pub use rolling_oaks::{
+	RollingOaksBraidOak, RollingOaksCell, RollingOaksItem, RollingOaksStorybook,
+};
+pub use forlorn_savanna::{
+	ForlornSavannaCell, ForlornSavannaHighBush, ForlornSavannaItem, ForlornSavannaRory,
+	ForlornSavannaStorybook,
+};
+pub use orchard::{OrchardCell, OrchardItem, OrchardStorybook};
 pub use conifer_sapling::{
 	ConiferSaplingCell, ConiferSaplingFriendsConifer, ConiferSaplingItem,
 	ConiferSaplingNorthernConifer,
@@ -158,6 +184,18 @@ pub use leeward::{Leeward, LeewardStd};
 #[cfg(feature = "render")]
 pub use christmas_taiga::{ChristmasTaiga, ChristmasTaigaStd};
 #[cfg(feature = "render")]
+pub use conifer_massives::{ConiferMassives, ConiferMassivesStd};
+#[cfg(feature = "render")]
+pub use temperate_massives::{TemperateMassives, TemperateMassivesStd};
+#[cfg(feature = "render")]
+pub use riparian_general::{RiparianGeneral, RiparianGeneralStd};
+#[cfg(feature = "render")]
+pub use rolling_oaks::{RollingOaks, RollingOaksStd};
+#[cfg(feature = "render")]
+pub use forlorn_savanna::{ForlornSavanna, ForlornSavannaStd};
+#[cfg(feature = "render")]
+pub use orchard::{Orchard, OrchardStd};
+#[cfg(feature = "render")]
 pub use braid_grass::{BraidGrass, BraidGrassStd};
 #[cfg(feature = "render")]
 pub use bush_scrub::{BushScrub, BushScrubStd};
@@ -204,30 +242,4 @@ pub use tropical_undergrowth::{TropicalUndergrowth, TropicalUndergrowthStd};
 #[cfg(feature = "render")]
 pub use unending_jungle::{UnendingJungle, UnendingJungleStd};
 #[cfg(feature = "render")]
-pub use wild_grass::{WildGrass, WildGrassStd};pub mod conifer_massives;
-pub mod temperate_massives;
-pub mod riparian_general;
-pub mod rolling_oaks;
-pub mod forlorn_savanna;
-pub mod orchard;
-pub use conifer_massives::{
-	ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
-	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
-pub use temperate_massives::{
-	TemperateMassivesBraidOak, TemperateMassivesCell, TemperateMassivesItem, TemperateMassivesRory,
-	TemperateMassivesStorybook,
-pub use riparian_general::{
-	RiparianGeneralBraidOak, RiparianGeneralCell, RiparianGeneralHighBush, RiparianGeneralItem,
-	RiparianGeneralStorybook,
-pub use rolling_oaks::{
-	RollingOaksBraidOak, RollingOaksCell, RollingOaksItem, RollingOaksStorybook,
-pub use forlorn_savanna::{
-	ForlornSavannaCell, ForlornSavannaHighBush, ForlornSavannaItem, ForlornSavannaRory,
-	ForlornSavannaStorybook,
-pub use orchard::{OrchardCell, OrchardItem, OrchardStorybook};
-pub use conifer_massives::{ConiferMassives, ConiferMassivesStd};
-pub use temperate_massives::{TemperateMassives, TemperateMassivesStd};
-pub use riparian_general::{RiparianGeneral, RiparianGeneralStd};
-pub use rolling_oaks::{RollingOaks, RollingOaksStd};
-pub use forlorn_savanna::{ForlornSavanna, ForlornSavannaStd};
-pub use orchard::{Orchard, OrchardStd};
+pub use wild_grass::{WildGrass, WildGrassStd};

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -207,6 +207,7 @@ pub use unending_jungle::{UnendingJungle, UnendingJungleStd};
 pub use wild_grass::{WildGrass, WildGrassStd};pub mod conifer_massives;
 pub mod temperate_massives;
 pub mod riparian_general;
+pub mod rolling_oaks;
 pub use conifer_massives::{
 	ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
 	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
@@ -216,6 +217,9 @@ pub use temperate_massives::{
 pub use riparian_general::{
 	RiparianGeneralBraidOak, RiparianGeneralCell, RiparianGeneralHighBush, RiparianGeneralItem,
 	RiparianGeneralStorybook,
+pub use rolling_oaks::{
+	RollingOaksBraidOak, RollingOaksCell, RollingOaksItem, RollingOaksStorybook,
 pub use conifer_massives::{ConiferMassives, ConiferMassivesStd};
 pub use temperate_massives::{TemperateMassives, TemperateMassivesStd};
 pub use riparian_general::{RiparianGeneral, RiparianGeneralStd};
+pub use rolling_oaks::{RollingOaks, RollingOaksStd};

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -204,4 +204,8 @@ pub use tropical_undergrowth::{TropicalUndergrowth, TropicalUndergrowthStd};
 #[cfg(feature = "render")]
 pub use unending_jungle::{UnendingJungle, UnendingJungleStd};
 #[cfg(feature = "render")]
-pub use wild_grass::{WildGrass, WildGrassStd};
+pub use wild_grass::{WildGrass, WildGrassStd};pub mod conifer_massives;
+pub use conifer_massives::{
+	ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
+	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
+pub use conifer_massives::{ConiferMassives, ConiferMassivesStd};

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -20,6 +20,7 @@ pub mod rolling_oaks;
 pub mod forlorn_savanna;
 pub mod orchard;
 pub mod vineyard;
+pub mod date_grove;
 pub mod conifer_sapling;
 pub mod goettingen_follow;
 pub mod high_bush;
@@ -104,6 +105,7 @@ pub use forlorn_savanna::{
 };
 pub use orchard::{OrchardCell, OrchardItem, OrchardStorybook};
 pub use vineyard::{VineyardCell, VineyardItem, VineyardRory};
+pub use date_grove::{DateGroveCell, DateGroveDatePalm, DateGroveItem};
 pub use conifer_sapling::{
 	ConiferSaplingCell, ConiferSaplingFriendsConifer, ConiferSaplingItem,
 	ConiferSaplingNorthernConifer,
@@ -199,6 +201,8 @@ pub use forlorn_savanna::{ForlornSavanna, ForlornSavannaStd};
 pub use orchard::{Orchard, OrchardStd};
 #[cfg(feature = "render")]
 pub use vineyard::{Vineyard, VineyardStd};
+#[cfg(feature = "render")]
+pub use date_grove::{DateGrove, DateGroveStd};
 #[cfg(feature = "render")]
 pub use braid_grass::{BraidGrass, BraidGrassStd};
 #[cfg(feature = "render")]

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -206,11 +206,16 @@ pub use unending_jungle::{UnendingJungle, UnendingJungleStd};
 #[cfg(feature = "render")]
 pub use wild_grass::{WildGrass, WildGrassStd};pub mod conifer_massives;
 pub mod temperate_massives;
+pub mod riparian_general;
 pub use conifer_massives::{
 	ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
 	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
 pub use temperate_massives::{
 	TemperateMassivesBraidOak, TemperateMassivesCell, TemperateMassivesItem, TemperateMassivesRory,
 	TemperateMassivesStorybook,
+pub use riparian_general::{
+	RiparianGeneralBraidOak, RiparianGeneralCell, RiparianGeneralHighBush, RiparianGeneralItem,
+	RiparianGeneralStorybook,
 pub use conifer_massives::{ConiferMassives, ConiferMassivesStd};
 pub use temperate_massives::{TemperateMassives, TemperateMassivesStd};
+pub use riparian_general::{RiparianGeneral, RiparianGeneralStd};

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -205,7 +205,12 @@ pub use tropical_undergrowth::{TropicalUndergrowth, TropicalUndergrowthStd};
 pub use unending_jungle::{UnendingJungle, UnendingJungleStd};
 #[cfg(feature = "render")]
 pub use wild_grass::{WildGrass, WildGrassStd};pub mod conifer_massives;
+pub mod temperate_massives;
 pub use conifer_massives::{
 	ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
 	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
+pub use temperate_massives::{
+	TemperateMassivesBraidOak, TemperateMassivesCell, TemperateMassivesItem, TemperateMassivesRory,
+	TemperateMassivesStorybook,
 pub use conifer_massives::{ConiferMassives, ConiferMassivesStd};
+pub use temperate_massives::{TemperateMassives, TemperateMassivesStd};

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -209,6 +209,7 @@ pub mod temperate_massives;
 pub mod riparian_general;
 pub mod rolling_oaks;
 pub mod forlorn_savanna;
+pub mod orchard;
 pub use conifer_massives::{
 	ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
 	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
@@ -223,8 +224,10 @@ pub use rolling_oaks::{
 pub use forlorn_savanna::{
 	ForlornSavannaCell, ForlornSavannaHighBush, ForlornSavannaItem, ForlornSavannaRory,
 	ForlornSavannaStorybook,
+pub use orchard::{OrchardCell, OrchardItem, OrchardStorybook};
 pub use conifer_massives::{ConiferMassives, ConiferMassivesStd};
 pub use temperate_massives::{TemperateMassives, TemperateMassivesStd};
 pub use riparian_general::{RiparianGeneral, RiparianGeneralStd};
 pub use rolling_oaks::{RollingOaks, RollingOaksStd};
 pub use forlorn_savanna::{ForlornSavanna, ForlornSavannaStd};
+pub use orchard::{Orchard, OrchardStd};

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -12,6 +12,7 @@ pub mod storytellers;
 pub mod trade_winds;
 pub mod wandering_acacia;
 pub mod leeward;
+pub mod christmas_taiga;
 pub mod conifer_sapling;
 pub mod goettingen_follow;
 pub mod high_bush;
@@ -71,6 +72,9 @@ pub use wandering_acacia::{
 };
 pub use leeward::{
 	LeewardCell, LeewardItem, LeewardStorybook, LeewardTemperateConifer,
+};
+pub use christmas_taiga::{
+	ChristmasTaigaCell, ChristmasTaigaItem, ChristmasTaigaNorthernConifer,
 };
 pub use conifer_sapling::{
 	ConiferSaplingCell, ConiferSaplingFriendsConifer, ConiferSaplingItem,
@@ -151,6 +155,8 @@ pub use trade_winds::{TradeWinds, TradeWindsStd};
 pub use wandering_acacia::{WanderingAcacia, WanderingAcaciaStd};
 #[cfg(feature = "render")]
 pub use leeward::{Leeward, LeewardStd};
+#[cfg(feature = "render")]
+pub use christmas_taiga::{ChristmasTaiga, ChristmasTaigaStd};
 #[cfg(feature = "render")]
 pub use braid_grass::{BraidGrass, BraidGrassStd};
 #[cfg(feature = "render")]

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -208,6 +208,7 @@ pub use wild_grass::{WildGrass, WildGrassStd};pub mod conifer_massives;
 pub mod temperate_massives;
 pub mod riparian_general;
 pub mod rolling_oaks;
+pub mod forlorn_savanna;
 pub use conifer_massives::{
 	ConiferMassivesCell, ConiferMassivesFriendsConifer, ConiferMassivesItem,
 	ConiferMassivesLiamsConifer, ConiferMassivesNorthernConifer, ConiferMassivesTemperateConifer,
@@ -219,7 +220,11 @@ pub use riparian_general::{
 	RiparianGeneralStorybook,
 pub use rolling_oaks::{
 	RollingOaksBraidOak, RollingOaksCell, RollingOaksItem, RollingOaksStorybook,
+pub use forlorn_savanna::{
+	ForlornSavannaCell, ForlornSavannaHighBush, ForlornSavannaItem, ForlornSavannaRory,
+	ForlornSavannaStorybook,
 pub use conifer_massives::{ConiferMassives, ConiferMassivesStd};
 pub use temperate_massives::{TemperateMassives, TemperateMassivesStd};
 pub use riparian_general::{RiparianGeneral, RiparianGeneralStd};
 pub use rolling_oaks::{RollingOaks, RollingOaksStd};
+pub use forlorn_savanna::{ForlornSavanna, ForlornSavannaStd};

--- a/maybraid/chico/groves/src/lib.rs
+++ b/maybraid/chico/groves/src/lib.rs
@@ -19,6 +19,7 @@ pub mod riparian_general;
 pub mod rolling_oaks;
 pub mod forlorn_savanna;
 pub mod orchard;
+pub mod vineyard;
 pub mod conifer_sapling;
 pub mod goettingen_follow;
 pub mod high_bush;
@@ -102,6 +103,7 @@ pub use forlorn_savanna::{
 	ForlornSavannaStorybook,
 };
 pub use orchard::{OrchardCell, OrchardItem, OrchardStorybook};
+pub use vineyard::{VineyardCell, VineyardItem, VineyardRory};
 pub use conifer_sapling::{
 	ConiferSaplingCell, ConiferSaplingFriendsConifer, ConiferSaplingItem,
 	ConiferSaplingNorthernConifer,
@@ -195,6 +197,8 @@ pub use rolling_oaks::{RollingOaks, RollingOaksStd};
 pub use forlorn_savanna::{ForlornSavanna, ForlornSavannaStd};
 #[cfg(feature = "render")]
 pub use orchard::{Orchard, OrchardStd};
+#[cfg(feature = "render")]
+pub use vineyard::{Vineyard, VineyardStd};
 #[cfg(feature = "render")]
 pub use braid_grass::{BraidGrass, BraidGrassStd};
 #[cfg(feature = "render")]

--- a/maybraid/chico/groves/src/orchard.rs
+++ b/maybraid/chico/groves/src/orchard.rs
@@ -1,4 +1,4 @@
-//! Orchard — moderate-density cultivated Storybook Tree upper-canopy grove
+//! Orchard — high-density cultivated Storybook Tree upper-canopy grove
 //! ([RFC-183 §3.4.7.7], [#353](https://github.com/ramate-io/maybraid/issues/353)).
 //!
 //! Compact fruiting and pale-bloom storybook forms on low-slope terrain with tight cell offset.
@@ -22,14 +22,14 @@ const MODERATE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
 
 /// Authored Orchard grove definition.
 ///
-/// Cell footprint sits at the RFC midpoint (`11.0` m). Offset stays tight so placements read as
-/// tended rows without snapping to a rigid grid.
+/// Cell footprint sits at the RFC midpoint (`11.0` m). Placements stay on cell centroids with only
+/// ±`0.5` m horizontal jitter so the grove reads as regular tended rows.
 pub fn definition() -> GroveDefinition<OrchardCell> {
 	GroveDefinition {
 		cell_extent_xz: Vec2::splat(11.0),
 		placement: GrovePlacementRanges::new(
-			UnitRange::new(0.85, 1.15),
-			UnitRange::new(-2.0, 2.0),
+			UnitRange::new(1.0, 1.0),
+			UnitRange::new(-0.5, 0.5),
 		),
 		distribution: OrchardCell::distribution(),
 	}
@@ -60,14 +60,14 @@ pub struct OrchardStorybook {
 
 const FRUITING_STORYBOOK: OrchardStorybook = OrchardStorybook {
 	height: UnitRange::new(5.0, 10.0),
-	stalk_radius: UnitRange::new(0.14, 0.30),
+	stalk_radius: UnitRange::new(0.22, 0.44),
 	canopy_spread: UnitRange::new(1.8, 4.2),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };
 
 const PALE_BLOOM_STORYBOOK: OrchardStorybook = OrchardStorybook {
 	height: UnitRange::new(5.0, 9.0),
-	stalk_radius: UnitRange::new(0.12, 0.28),
+	stalk_radius: UnitRange::new(0.20, 0.38),
 	canopy_spread: UnitRange::new(1.6, 3.8),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };
@@ -92,18 +92,21 @@ const PALE_BLOOM_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
 	PaletteSlot::new("light_green", "yellow_green"),
 ]);
 
+/// Explicit `None` weight paired with placed weights so ~`95%` of cells receive a tree.
+const CULTIVATED_EMPTY_WEIGHT: f32 = 2.25 / 19.0;
+
 impl OrchardCell {
 	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
 	///
-	/// Placed weights total `2.25`; the `None` weight of `5.0` puts the placed share at
-	/// `2.25 / 7.25 ≈ 0.31`, mid RFC `DENSITY_RANGE` (`0.24..0.44`).
+	/// Placed weights total `2.25`; the `None` weight of `2.25 / 19` yields a `~0.95` placed share
+	/// for regular tended-row planting.
 	pub fn distribution() -> GroveDistribution<Self> {
 		let fruiting =
 			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.30));
 		let pale_bloom =
 			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.28));
 		GroveDistribution::new(vec![
-			GroveBucket::none(5.0),
+			GroveBucket::none(CULTIVATED_EMPTY_WEIGHT),
 			GroveBucket::placed(1.5, fruiting, Self::FruitingStorybook),
 			GroveBucket::placed(0.75, pale_bloom, Self::PaleBloomStorybook),
 		])
@@ -146,7 +149,7 @@ mod tests {
 		let dist = OrchardCell::distribution();
 		assert_eq!(dist.len(), 3);
 		assert!(dist.buckets[0].item.is_none());
-		assert_eq!(dist.buckets[0].weight, 5.0);
+		assert_eq!(dist.buckets[0].weight, CULTIVATED_EMPTY_WEIGHT);
 		assert_eq!(dist.buckets[1].item, Some(OrchardCell::FruitingStorybook));
 		assert_eq!(dist.buckets[1].weight, 1.5);
 		assert_eq!(dist.buckets[2].item, Some(OrchardCell::PaleBloomStorybook));
@@ -155,12 +158,15 @@ mod tests {
 	}
 
 	#[test]
-	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+	fn placed_share_targets_cultivated_fill() -> Result<()> {
 		let dist = OrchardCell::distribution();
 		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
 		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
 		let share = placed / total;
-		assert!((0.24..=0.44).contains(&share), "placed share {share} outside RFC density");
+		assert!(
+			(0.94..=0.96).contains(&share),
+			"placed share {share} outside cultivated ~95% target"
+		);
 		Ok(())
 	}
 
@@ -239,6 +245,14 @@ mod tests {
 				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
 			}
 		}
+		Ok(())
+	}
+
+	#[test]
+	fn placement_uses_tight_centroid_offset_and_uniform_scale() -> Result<()> {
+		let def = definition();
+		assert_eq!(def.placement.offset, UnitRange::new(-0.5, 0.5));
+		assert_eq!(def.placement.scale, UnitRange::new(1.0, 1.0));
 		Ok(())
 	}
 

--- a/maybraid/chico/groves/src/orchard.rs
+++ b/maybraid/chico/groves/src/orchard.rs
@@ -1,0 +1,257 @@
+//! Orchard — moderate-density cultivated Storybook Tree upper-canopy grove
+//! ([RFC-183 §3.4.7.7], [#353](https://github.com/ramate-io/maybraid/issues/353)).
+//!
+//! Compact fruiting and pale-bloom storybook forms on low-slope terrain with tight cell offset.
+//! Forest-layer attachment remains a follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{Orchard, OrchardStd};
+
+/// Moderate sampled canopy-density band ([`0.35`, `0.65`]).
+const MODERATE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
+
+/// Authored Orchard grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`11.0` m). Offset stays tight so placements read as
+/// tended rows without snapping to a rigid grid.
+pub fn definition() -> GroveDefinition<OrchardCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(11.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-2.0, 2.0),
+		),
+		distribution: OrchardCell::distribution(),
+	}
+}
+
+/// Ordered orchard varietals ([RFC-183 §3.4.7.7]); the explicit `None` bucket lives only in the
+/// distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrchardCell {
+	FruitingStorybook,
+	PaleBloomStorybook,
+}
+
+/// Typed authored geometry for one orchard varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OrchardItem {
+	Storybook(&'static OrchardStorybook),
+}
+
+/// Authored geometry ranges for one cultivated Storybook Tree form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrchardStorybook {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const FRUITING_STORYBOOK: OrchardStorybook = OrchardStorybook {
+	height: UnitRange::new(5.0, 10.0),
+	stalk_radius: UnitRange::new(0.14, 0.30),
+	canopy_spread: UnitRange::new(1.8, 4.2),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const PALE_BLOOM_STORYBOOK: OrchardStorybook = OrchardStorybook {
+	height: UnitRange::new(5.0, 9.0),
+	stalk_radius: UnitRange::new(0.12, 0.28),
+	canopy_spread: UnitRange::new(1.6, 3.8),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const FRUITING_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("orchard_bark", "brown_bark"),
+	PaletteSlot::new("gray_brown", "dark_bark"),
+]);
+
+const FRUITING_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("fresh_green", "light_green"),
+	PaletteSlot::new("deep_green", "yellow_green"),
+]);
+
+const PALE_BLOOM_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("orchard_bark", "gray_brown"),
+	PaletteSlot::new("tan_bark", "brown_bark"),
+]);
+
+const PALE_BLOOM_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("pale_blossom", "fresh_green"),
+	PaletteSlot::new("light_green", "yellow_green"),
+]);
+
+impl OrchardCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `2.25`; the `None` weight of `5.0` puts the placed share at
+	/// `2.25 / 7.25 ≈ 0.31`, mid RFC `DENSITY_RANGE` (`0.24..0.44`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let fruiting =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.30));
+		let pale_bloom =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.28));
+		GroveDistribution::new(vec![
+			GroveBucket::none(5.0),
+			GroveBucket::placed(1.5, fruiting, Self::FruitingStorybook),
+			GroveBucket::placed(0.75, pale_bloom, Self::PaleBloomStorybook),
+		])
+	}
+
+	pub fn item(self) -> OrchardItem {
+		match self {
+			Self::FruitingStorybook => OrchardItem::Storybook(&FRUITING_STORYBOOK),
+			Self::PaleBloomStorybook => OrchardItem::Storybook(&PALE_BLOOM_STORYBOOK),
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::FruitingStorybook => FRUITING_STICK_MIX,
+			Self::PaleBloomStorybook => PALE_BLOOM_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::FruitingStorybook => FRUITING_CANOPY_MIX,
+			Self::PaleBloomStorybook => PALE_BLOOM_CANOPY_MIX,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveCellOutcome, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+	use procedural_common::NoiseParams;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = OrchardCell::distribution();
+		assert_eq!(dist.len(), 3);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 5.0);
+		assert_eq!(dist.buckets[1].item, Some(OrchardCell::FruitingStorybook));
+		assert_eq!(dist.buckets[1].weight, 1.5);
+		assert_eq!(dist.buckets[2].item, Some(OrchardCell::PaleBloomStorybook));
+		assert_eq!(dist.buckets[2].weight, 0.75);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = OrchardCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.24..=0.44).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let OrchardItem::Storybook(fruiting) = OrchardCell::FruitingStorybook.item() else {
+			anyhow::bail!("expected fruiting storybook item");
+		};
+		assert_eq!(fruiting.height, UnitRange::new(5.0, 10.0));
+		assert_eq!(fruiting.canopy_density, MODERATE_CANOPY_DENSITY);
+
+		let OrchardItem::Storybook(pale) = OrchardCell::PaleBloomStorybook.item() else {
+			anyhow::bail!("expected pale bloom storybook item");
+		};
+		assert_eq!(pale.height, UnitRange::new(5.0, 9.0));
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_use_full_elevation_and_rfc_steepness() -> Result<()> {
+		let dist = OrchardCell::distribution();
+		for bucket in dist.buckets.iter().filter(|b| b.item.is_some()) {
+			assert_eq!(bucket.constraints.elevation.start, 0.0);
+			assert_eq!(bucket.constraints.elevation.end, 1.0);
+		}
+		let fruiting = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(OrchardCell::FruitingStorybook))
+			.ok_or_else(|| anyhow::anyhow!("missing fruiting bucket"))?;
+		assert_eq!(fruiting.constraints.steepness.end, 0.30);
+
+		let pale = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(OrchardCell::PaleBloomStorybook))
+			.ok_or_else(|| anyhow::anyhow!("missing pale bloom bucket"))?;
+		assert_eq!(pale.constraints.steepness.end, 0.28);
+		Ok(())
+	}
+
+	#[test]
+	fn steep_slope_rejects_fruiting_but_allows_pale_on_gentler_band() -> Result<()> {
+		let prepared =
+			OrchardCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
+		let gentle = FlatTerrainSample { elevation: 0.40, steepness: 0.25 };
+		let fruiting_outcome = prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &gentle);
+		match fruiting_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_eq!(variant, OrchardCell::FruitingStorybook);
+			}
+			other => anyhow::bail!("expected FruitingStorybook on gentle slope, got {other:?}"),
+		}
+		let steep = FlatTerrainSample { elevation: 0.40, steepness: 0.32 };
+		let steep_outcome = prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &steep);
+		match steep_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_ne!(variant, OrchardCell::FruitingStorybook);
+			}
+			GroveCellOutcome::Empty { .. } | GroveCellOutcome::Rejected { .. } => {}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [OrchardCell::FruitingStorybook, OrchardCell::PaleBloomStorybook] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(120.0, 1.0, 120.0));
+		let terrain = FlatTerrainSample { elevation: 0.35, steepness: 0.10 };
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/orchard/render.rs
+++ b/maybraid/chico/groves/src/orchard/render.rs
@@ -1,0 +1,332 @@
+//! [`RenderItem`] for populated Orchard groves ([#353](https://github.com/ramate-io/maybraid/issues/353)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::StorybookTreeSbs;
+use chico_sbs_trees::storybook_tree::StorybookTree;
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::orchard::{definition, OrchardCell, OrchardItem, OrchardStorybook};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Orchard instance.
+pub type OrchardStd = Orchard<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Orchard grove preview (compact cultivated storybook forms).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct Orchard<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<OrchardCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for Orchard<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Orchard<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<OrchardCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<OrchardCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+fn span_fraction(canopy_spread: f32, height: f32) -> f32 {
+	(canopy_spread / height.max(0.5)).clamp(0.35, 1.20)
+}
+
+/// Tighter ring spacing than wild storybook forms for cultivated orchard crowns.
+const ORCHARD_RING_SPACING_SCALE: f32 = 0.85;
+const ORCHARD_ANCHORS_PER_RING: u32 = 6;
+
+fn orchard_ring_spacing(base: f32) -> f32 {
+	base * ORCHARD_RING_SPACING_SCALE
+}
+
+impl BuildWithNoise<StorybookTreeSbs> for OrchardStorybook {
+	fn build_with_noise(&self, noise: NoiseParams) -> StorybookTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 4.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = StorybookTreeSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.rings.spacing = orchard_ring_spacing(geometry.rings.spacing);
+		geometry.rings.anchors_per_ring =
+			ORCHARD_ANCHORS_PER_RING + (canopy_density * 2.0).round() as u32;
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.05);
+		geometry.rings.height_range = UnitRange::new(0.55, 1.0);
+		geometry.canopy_noise = noise;
+		geometry
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for Orchard<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let OrchardItem::Storybook(story) = placed.variant.item();
+			let geometry = story.build_with_noise(build_noise);
+			let mut tree = StorybookTree::<StickM, StickS, LeafM, LeafS>::default();
+			tree.geometry = geometry;
+			tree.stick_material = self.stick_material.clone();
+			tree.leaf_material = self.leaf_material.clone();
+			tree.stick_surface_noise = placement_noise(self.stick_surface_noise, placed.position);
+			tree.leaf_surface_noise = foliage_noise;
+			let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+			patch_spawned_leaf_material::<StickM>(
+				&entities,
+				placed.variant.stick_palette_mix(),
+				stick_seed,
+				commands,
+			);
+			patch_spawned_leaf_material::<LeafM>(
+				&entities,
+				placed.variant.canopy_palette_mix(),
+				canopy_seed,
+				commands,
+			);
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let OrchardItem::Storybook(fruiting) = OrchardCell::FruitingStorybook.item() else {
+			anyhow::bail!("expected fruiting storybook item");
+		};
+		let story_geom = fruiting.build_with_noise(noise);
+		assert!(story_geom.scale.tree_height >= fruiting.height.start.min(fruiting.height.end));
+		assert!(story_geom.scale.tree_height <= fruiting.height.start.max(fruiting.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [OrchardCell::FruitingStorybook, OrchardCell::PaleBloomStorybook] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn with_resolved_placements_skips_live_selection() -> Result<()> {
+		let placement =
+			GrovePlacedCell::new(OrchardCell::FruitingStorybook, Vec3::new(1.0, 0.0, 2.0), 1.0);
+		let item = OrchardStd::with_resolved_placements(
+			vec![placement.clone()],
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			GroveSkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements(), vec![placement]);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/riparian_general.rs
+++ b/maybraid/chico/groves/src/riparian_general.rs
@@ -91,7 +91,7 @@ const RIPARIAN_BRAID_OAK: RiparianGeneralBraidOak = RiparianGeneralBraidOak {
 
 const RIPARIAN_STORYBOOK: RiparianGeneralStorybook = RiparianGeneralStorybook {
 	height: UnitRange::new(5.0, 15.0),
-	stalk_radius: UnitRange::new(0.12, 0.28),
+	stalk_radius: UnitRange::new(0.20, 0.42),
 	canopy_spread: UnitRange::new(2.0, 5.5),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };
@@ -142,11 +142,11 @@ impl RiparianGeneralCell {
 	/// `3.35 / 10.75 ≈ 0.31`, mid RFC `DENSITY_RANGE` (`0.20..0.42`).
 	pub fn distribution() -> GroveDistribution<Self> {
 		let braid_oak =
-			PlacementConstraints::new(UnitRange::new(0.0, 0.42), UnitRange::new(0.0, 0.36));
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.36));
 		let storybook =
-			PlacementConstraints::new(UnitRange::new(0.0, 0.45), UnitRange::new(0.0, 0.44));
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.44));
 		let high_bush =
-			PlacementConstraints::new(UnitRange::new(0.0, 0.38), UnitRange::new(0.0, 0.52));
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.52));
 		GroveDistribution::new(vec![
 			GroveBucket::none(7.4),
 			GroveBucket::placed(1.5, braid_oak, Self::RiparianBraidOak),
@@ -247,7 +247,8 @@ mod tests {
 			.iter()
 			.find(|b| b.item == Some(RiparianGeneralCell::RiparianBraidOak))
 			.ok_or_else(|| anyhow::anyhow!("missing braid oak bucket"))?;
-		assert_eq!(braid_oak.constraints.elevation.end, 0.42);
+		assert_eq!(braid_oak.constraints.elevation.start, 0.0);
+		assert_eq!(braid_oak.constraints.elevation.end, 1.0);
 		assert_eq!(braid_oak.constraints.steepness.end, 0.36);
 
 		let storybook = dist
@@ -255,7 +256,8 @@ mod tests {
 			.iter()
 			.find(|b| b.item == Some(RiparianGeneralCell::RiparianStorybook))
 			.ok_or_else(|| anyhow::anyhow!("missing storybook bucket"))?;
-		assert_eq!(storybook.constraints.elevation.end, 0.45);
+		assert_eq!(storybook.constraints.elevation.start, 0.0);
+		assert_eq!(storybook.constraints.elevation.end, 1.0);
 		assert_eq!(storybook.constraints.steepness.end, 0.44);
 
 		let high_bush = dist
@@ -263,7 +265,8 @@ mod tests {
 			.iter()
 			.find(|b| b.item == Some(RiparianGeneralCell::RareRiparianHighBush))
 			.ok_or_else(|| anyhow::anyhow!("missing high bush bucket"))?;
-		assert_eq!(high_bush.constraints.elevation.end, 0.38);
+		assert_eq!(high_bush.constraints.elevation.start, 0.0);
+		assert_eq!(high_bush.constraints.elevation.end, 1.0);
 		assert_eq!(high_bush.constraints.steepness.end, 0.52);
 		Ok(())
 	}

--- a/maybraid/chico/groves/src/riparian_general.rs
+++ b/maybraid/chico/groves/src/riparian_general.rs
@@ -1,0 +1,326 @@
+//! Riparian General — moderate-density mixed river-corridor upper-canopy grove
+//! ([RFC-183 §3.4.7.4], [#347](https://github.com/ramate-io/maybraid/issues/347)).
+//!
+//! Common Braid Oak and Storybook Tree forms with rare willow-like High Bush accents. Forest-layer
+//! attachment remains a follow-up.
+
+use std::ops::RangeInclusive;
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{RiparianGeneral, RiparianGeneralStd};
+
+const MODERATE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
+/// Flat sparse crown projection for willow-like High Bush forms.
+const SPARSE_PROJECTION_RADIAL: UnitRange = UnitRange::new(0.42, 0.62);
+const SPARSE_PROJECTION_VERTICAL: UnitRange = UnitRange::new(0.32, 0.52);
+
+/// Authored Riparian General grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`16` m). The offset range is signed and ± one cell so
+/// placements break the underlying grid instead of clustering near cell centers.
+pub fn definition() -> GroveDefinition<RiparianGeneralCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(16.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-16.0, 16.0),
+		),
+		distribution: RiparianGeneralCell::distribution(),
+	}
+}
+
+/// Ordered riparian-general varietals ([RFC-183 §3.4.7.4]); the explicit `None` bucket lives only
+/// in the distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RiparianGeneralCell {
+	RiparianBraidOak,
+	RiparianStorybook,
+	RareRiparianHighBush,
+}
+
+/// Typed authored geometry for one riparian-general varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RiparianGeneralItem {
+	BraidOak(&'static RiparianGeneralBraidOak),
+	Storybook(&'static RiparianGeneralStorybook),
+	HighBush(&'static RiparianGeneralHighBush),
+}
+
+/// Authored geometry ranges for one Braid Oak form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RiparianGeneralBraidOak {
+	pub height: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one Storybook Tree form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RiparianGeneralStorybook {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one willow-like Common High Bush form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RiparianGeneralHighBush {
+	pub height: UnitRange,
+	pub shoot_count: RangeInclusive<u32>,
+	pub branch_depth: RangeInclusive<u32>,
+	pub radial_strength: UnitRange,
+	pub vertical_bias: UnitRange,
+	/// Terminal foliage radius in **world meters** (render converts to a height fraction).
+	pub leaf_radius: UnitRange,
+}
+
+const RIPARIAN_BRAID_OAK: RiparianGeneralBraidOak = RiparianGeneralBraidOak {
+	height: UnitRange::new(5.0, 15.0),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const RIPARIAN_STORYBOOK: RiparianGeneralStorybook = RiparianGeneralStorybook {
+	height: UnitRange::new(5.0, 15.0),
+	stalk_radius: UnitRange::new(0.12, 0.28),
+	canopy_spread: UnitRange::new(2.0, 5.5),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const RARE_RIPARIAN_HIGH_BUSH: RiparianGeneralHighBush = RiparianGeneralHighBush {
+	height: UnitRange::new(5.0, 15.0),
+	shoot_count: 5..=14,
+	branch_depth: 2..=4,
+	radial_strength: SPARSE_PROJECTION_RADIAL,
+	vertical_bias: SPARSE_PROJECTION_VERTICAL,
+	leaf_radius: UnitRange::new(0.12, 0.28),
+};
+
+const RIPARIAN_BRAID_OAK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("wet_oak_bark", "dark_bark"),
+	PaletteSlot::new("moss_bark", "gray_brown"),
+]);
+
+const RIPARIAN_BRAID_OAK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("river_green", "fresh_green"),
+	PaletteSlot::new("deep_green", "yellow_green"),
+]);
+
+const RIPARIAN_STORYBOOK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("broadleaf_bark", "wet_brown"),
+	PaletteSlot::new("gray_brown", "dark_bark"),
+]);
+
+const RIPARIAN_STORYBOOK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("river_green", "light_green"),
+	PaletteSlot::new("deep_green", "fresh_green"),
+]);
+
+const RIPARIAN_HIGH_BUSH_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("willow_bark", "wet_brown"),
+	PaletteSlot::new("red_brown", "gray_brown"),
+]);
+
+const RIPARIAN_HIGH_BUSH_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("fresh_green", "yellow_green"),
+	PaletteSlot::new("river_green", "light_green"),
+]);
+
+impl RiparianGeneralCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `3.35`; the `None` weight of `7.4` puts the placed share at
+	/// `3.35 / 10.75 ≈ 0.31`, mid RFC `DENSITY_RANGE` (`0.20..0.42`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let braid_oak =
+			PlacementConstraints::new(UnitRange::new(0.0, 0.42), UnitRange::new(0.0, 0.36));
+		let storybook =
+			PlacementConstraints::new(UnitRange::new(0.0, 0.45), UnitRange::new(0.0, 0.44));
+		let high_bush =
+			PlacementConstraints::new(UnitRange::new(0.0, 0.38), UnitRange::new(0.0, 0.52));
+		GroveDistribution::new(vec![
+			GroveBucket::none(7.4),
+			GroveBucket::placed(1.5, braid_oak, Self::RiparianBraidOak),
+			GroveBucket::placed(1.5, storybook, Self::RiparianStorybook),
+			GroveBucket::placed(0.35, high_bush, Self::RareRiparianHighBush),
+		])
+	}
+
+	pub fn item(self) -> RiparianGeneralItem {
+		match self {
+			Self::RiparianBraidOak => RiparianGeneralItem::BraidOak(&RIPARIAN_BRAID_OAK),
+			Self::RiparianStorybook => RiparianGeneralItem::Storybook(&RIPARIAN_STORYBOOK),
+			Self::RareRiparianHighBush => RiparianGeneralItem::HighBush(&RARE_RIPARIAN_HIGH_BUSH),
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::RiparianBraidOak => RIPARIAN_BRAID_OAK_STICK_MIX,
+			Self::RiparianStorybook => RIPARIAN_STORYBOOK_STICK_MIX,
+			Self::RareRiparianHighBush => RIPARIAN_HIGH_BUSH_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::RiparianBraidOak => RIPARIAN_BRAID_OAK_CANOPY_MIX,
+			Self::RiparianStorybook => RIPARIAN_STORYBOOK_CANOPY_MIX,
+			Self::RareRiparianHighBush => RIPARIAN_HIGH_BUSH_CANOPY_MIX,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveCellOutcome, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+	use procedural_common::NoiseParams;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = RiparianGeneralCell::distribution();
+		assert_eq!(dist.len(), 4);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 7.4);
+		assert_eq!(dist.buckets[1].item, Some(RiparianGeneralCell::RiparianBraidOak));
+		assert_eq!(dist.buckets[1].weight, 1.5);
+		assert_eq!(dist.buckets[2].item, Some(RiparianGeneralCell::RiparianStorybook));
+		assert_eq!(dist.buckets[2].weight, 1.5);
+		assert_eq!(dist.buckets[3].item, Some(RiparianGeneralCell::RareRiparianHighBush));
+		assert_eq!(dist.buckets[3].weight, 0.35);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = RiparianGeneralCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.20..=0.42).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let RiparianGeneralItem::BraidOak(oak) = RiparianGeneralCell::RiparianBraidOak.item() else {
+			anyhow::bail!("expected braid oak item");
+		};
+		assert_eq!(oak.height, UnitRange::new(5.0, 15.0));
+		assert_eq!(oak.canopy_density, MODERATE_CANOPY_DENSITY);
+
+		let RiparianGeneralItem::Storybook(story) = RiparianGeneralCell::RiparianStorybook.item()
+		else {
+			anyhow::bail!("expected storybook item");
+		};
+		assert_eq!(story.height, UnitRange::new(5.0, 15.0));
+		assert_eq!(story.canopy_density, MODERATE_CANOPY_DENSITY);
+
+		let RiparianGeneralItem::HighBush(bush) = RiparianGeneralCell::RareRiparianHighBush.item()
+		else {
+			anyhow::bail!("expected high bush item");
+		};
+		assert_eq!(bush.height, UnitRange::new(5.0, 15.0));
+		assert_eq!(bush.leaf_radius, UnitRange::new(0.12, 0.28));
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_match_rfc() -> Result<()> {
+		let dist = RiparianGeneralCell::distribution();
+		let braid_oak = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(RiparianGeneralCell::RiparianBraidOak))
+			.ok_or_else(|| anyhow::anyhow!("missing braid oak bucket"))?;
+		assert_eq!(braid_oak.constraints.elevation.end, 0.42);
+		assert_eq!(braid_oak.constraints.steepness.end, 0.36);
+
+		let storybook = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(RiparianGeneralCell::RiparianStorybook))
+			.ok_or_else(|| anyhow::anyhow!("missing storybook bucket"))?;
+		assert_eq!(storybook.constraints.elevation.end, 0.45);
+		assert_eq!(storybook.constraints.steepness.end, 0.44);
+
+		let high_bush = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(RiparianGeneralCell::RareRiparianHighBush))
+			.ok_or_else(|| anyhow::anyhow!("missing high bush bucket"))?;
+		assert_eq!(high_bush.constraints.elevation.end, 0.38);
+		assert_eq!(high_bush.constraints.steepness.end, 0.52);
+		Ok(())
+	}
+
+	#[test]
+	fn steep_slope_rejects_braid_oak_but_allows_high_bush() -> Result<()> {
+		let prepared =
+			RiparianGeneralCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
+		let terrain = FlatTerrainSample { elevation: 0.25, steepness: 0.45 };
+		let bush_outcome = prepared.select_from(5, Vec3::new(5.0, 0.25, 5.0), 1.0, &terrain);
+		match bush_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_eq!(variant, RiparianGeneralCell::RareRiparianHighBush);
+			}
+			other => anyhow::bail!("expected RareRiparianHighBush on moderate slope, got {other:?}"),
+		}
+		let braid_outcome = prepared.select_from(1, Vec3::new(5.0, 0.25, 5.0), 1.0, &terrain);
+		match braid_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_ne!(variant, RiparianGeneralCell::RiparianBraidOak);
+			}
+			GroveCellOutcome::Empty { .. } | GroveCellOutcome::Rejected { .. } => {}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			RiparianGeneralCell::RiparianBraidOak,
+			RiparianGeneralCell::RiparianStorybook,
+			RiparianGeneralCell::RareRiparianHighBush,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(160.0, 1.0, 160.0));
+		let terrain = FlatTerrainSample { elevation: 0.20, steepness: 0.10 };
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/riparian_general/render.rs
+++ b/maybraid/chico/groves/src/riparian_general/render.rs
@@ -1,0 +1,466 @@
+//! [`RenderItem`] for populated Riparian General groves ([#347](https://github.com/ramate-io/maybraid/issues/347)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::anchors::high_bush::{
+	DEFAULT_ANCHOR_LIFT_FRACTION, DEFAULT_SEGMENT_LENGTH_FRACTION_HI,
+	DEFAULT_SEGMENT_LENGTH_FRACTION_LO, DEFAULT_SEGMENT_RADIUS_FRACTION_HI,
+	DEFAULT_SEGMENT_RADIUS_FRACTION_LO,
+};
+use chico_sbs_geometry::{BraidOakTreeSbs, StorybookTreeSbs};
+use chico_sbs_trees::braid_oak_tree::BraidOakTree;
+use chico_sbs_trees::storybook_tree::StorybookTree;
+use chico_tree_components::{HighBushFoliageStyle, HighBushShoots, HighBushShootsShape};
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::riparian_general::{
+	definition, RiparianGeneralBraidOak, RiparianGeneralCell, RiparianGeneralHighBush,
+	RiparianGeneralItem, RiparianGeneralStorybook,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Riparian General instance.
+pub type RiparianGeneralStd = RiparianGeneral<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Riparian General grove preview (mixed river-corridor braid oak, storybook, and willow bush).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct RiparianGeneral<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<RiparianGeneralCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for RiparianGeneral<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RiparianGeneral<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<RiparianGeneralCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<RiparianGeneralCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+fn span_fraction(canopy_spread: f32, height: f32) -> f32 {
+	(canopy_spread / height.max(0.5)).clamp(0.25, 1.20)
+}
+
+const RIPARIAN_RING_SPACING_SCALE: f32 = 1.25;
+const RIPARIAN_ANCHORS_PER_RING: u32 = 5;
+
+fn riparian_ring_spacing(base: f32) -> f32 {
+	base * RIPARIAN_RING_SPACING_SCALE
+}
+
+impl BuildWithNoise<BraidOakTreeSbs> for RiparianGeneralBraidOak {
+	fn build_with_noise(&self, noise: NoiseParams) -> BraidOakTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let canopy_density = sample_f32(&config, self.canopy_density, 2.0);
+		let spread_lo = height * 0.35;
+		let spread_hi = height * 0.55;
+		let canopy_spread = sample_f32(&config, UnitRange::new(spread_lo, spread_hi), 3.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = BraidOakTreeSbs::default();
+		geometry.apply_braid_preset();
+		geometry.scale.tree_height = height;
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.02);
+		let _ = canopy_density;
+		geometry.canopy_noise = noise;
+		geometry
+	}
+}
+
+impl BuildWithNoise<StorybookTreeSbs> for RiparianGeneralStorybook {
+	fn build_with_noise(&self, noise: NoiseParams) -> StorybookTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 4.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = StorybookTreeSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.rings.spacing = riparian_ring_spacing(geometry.rings.spacing);
+		geometry.rings.anchors_per_ring =
+			RIPARIAN_ANCHORS_PER_RING + (canopy_density * 2.0).round() as u32;
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.05);
+		geometry.rings.height_range = UnitRange::new(0.58, 1.0);
+		geometry.canopy_noise = noise;
+		geometry
+	}
+}
+
+impl BuildWithNoise<HighBushShootsShape> for RiparianGeneralHighBush {
+	fn build_with_noise(&self, noise: NoiseParams) -> HighBushShootsShape {
+		let config = NoiseConfig::new(noise);
+		let sample_u32 = |range: &std::ops::RangeInclusive<u32>, salt| {
+			let lo = *range.start() as usize;
+			let hi = (*range.end() as usize).saturating_add(1);
+			config.sample_range_usize_4d(lo, hi, 0.0, 0.0, 0.0, salt) as u32
+		};
+
+		let height = sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let leaf_radius = sample_f32(&config, self.leaf_radius, 2.0).max(0.01);
+
+		HighBushShootsShape {
+			height,
+			anchor_lift_fraction: DEFAULT_ANCHOR_LIFT_FRACTION,
+			shoot_count: sample_u32(&self.shoot_count, 3.0),
+			radial_strength: sample_f32(&config, self.radial_strength, 5.0),
+			vertical_bias: sample_f32(&config, self.vertical_bias, 6.0),
+			branch_depth: sample_u32(&self.branch_depth, 4.0) as usize,
+			segment_length_fraction_lo: DEFAULT_SEGMENT_LENGTH_FRACTION_LO,
+			segment_length_fraction_hi: DEFAULT_SEGMENT_LENGTH_FRACTION_HI,
+			segment_radius_fraction_lo: DEFAULT_SEGMENT_RADIUS_FRACTION_LO,
+			segment_radius_fraction_hi: DEFAULT_SEGMENT_RADIUS_FRACTION_HI,
+			leaf_radius_fraction: leaf_radius / height,
+			foliage_style: HighBushFoliageStyle::PlaneSplay,
+			chain_noise: noise,
+		}
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for RiparianGeneral<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let entities = match placed.variant.item() {
+				RiparianGeneralItem::BraidOak(oak) => {
+					let geometry = oak.build_with_noise(build_noise);
+					let mut tree =
+						BraidOakTree::<StickM, StickS, LeafM, LeafS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.inner_leaf_material = self.leaf_material.clone();
+					tree.outer_leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.inner_leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				RiparianGeneralItem::Storybook(story) => {
+					let geometry = story.build_with_noise(build_noise);
+					let mut tree = StorybookTree::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				RiparianGeneralItem::HighBush(bush) => {
+					let mut shape = bush.build_with_noise(build_noise);
+					shape.chain_noise = chain_noise;
+					let entities = HighBushShoots::<StickM, StickS, LeafM, LeafS>::spawn_from_shape(
+						shape,
+						self.stick_surface_noise,
+						self.leaf_surface_noise,
+						self.stick_material.clone(),
+						self.leaf_material.clone(),
+						commands,
+						cascade_chunk,
+						local,
+					);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+			};
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let RiparianGeneralItem::BraidOak(oak) = RiparianGeneralCell::RiparianBraidOak.item() else {
+			anyhow::bail!("expected braid oak item");
+		};
+		let oak_geom = oak.build_with_noise(noise);
+		assert!(oak_geom.scale.tree_height >= oak.height.start.min(oak.height.end));
+		assert!(oak_geom.scale.tree_height <= oak.height.start.max(oak.height.end));
+
+		let RiparianGeneralItem::HighBush(bush) = RiparianGeneralCell::RareRiparianHighBush.item()
+		else {
+			anyhow::bail!("expected high bush item");
+		};
+		let shape = bush.build_with_noise(noise);
+		assert!(shape.height >= bush.height.start.min(bush.height.end));
+		assert!(shape.height <= bush.height.start.max(bush.height.end));
+		assert_eq!(shape.foliage_style, HighBushFoliageStyle::PlaneSplay);
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			RiparianGeneralCell::RiparianBraidOak,
+			RiparianGeneralCell::RiparianStorybook,
+			RiparianGeneralCell::RareRiparianHighBush,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn with_resolved_placements_skips_live_selection() -> Result<()> {
+		let placement = GrovePlacedCell::new(
+			RiparianGeneralCell::RiparianBraidOak,
+			Vec3::new(1.0, 0.0, 2.0),
+			1.0,
+		);
+		let item = RiparianGeneralStd::with_resolved_placements(
+			vec![placement.clone()],
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			GroveSkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements(), vec![placement]);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/riparian_mix.rs
+++ b/maybraid/chico/groves/src/riparian_mix.rs
@@ -102,14 +102,14 @@ const OVERBANK_BRAID_OAK: RiparianMixBraidOak = RiparianMixBraidOak {
 
 const ROUND_RIPARIAN_STORYBOOK: RiparianMixStorybook = RiparianMixStorybook {
 	height: UnitRange::new(5.0, 15.0),
-	stalk_radius: UnitRange::new(0.12, 0.28),
+	stalk_radius: UnitRange::new(0.18, 0.40),
 	canopy_spread: UnitRange::new(2.0, 5.5),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };
 
 const TALL_RIPARIAN_STORYBOOK: RiparianMixStorybook = RiparianMixStorybook {
 	height: UnitRange::new(12.0, 22.0),
-	stalk_radius: UnitRange::new(0.18, 0.38),
+	stalk_radius: UnitRange::new(0.26, 0.52),
 	canopy_spread: UnitRange::new(3.5, 8.0),
 	canopy_density: SPARSE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/groves/src/rolling_oaks.rs
+++ b/maybraid/chico/groves/src/rolling_oaks.rs
@@ -40,6 +40,8 @@ pub fn definition() -> GroveDefinition<RollingOaksCell> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RollingOaksCell {
 	RollingBraidOak,
+	RareTallRollingBraidOak,
+	RareSentinelRollingBraidOak,
 	RareRollingStorybook,
 }
 
@@ -73,9 +75,21 @@ const ROLLING_BRAID_OAK: RollingOaksBraidOak = RollingOaksBraidOak {
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };
 
+const RARE_TALL_ROLLING_BRAID_OAK: RollingOaksBraidOak = RollingOaksBraidOak {
+	height: UnitRange::new(20.0, 32.0),
+	canopy_spread: UnitRange::new(5.0, 11.0),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const RARE_SENTINEL_ROLLING_BRAID_OAK: RollingOaksBraidOak = RollingOaksBraidOak {
+	height: UnitRange::new(28.0, 40.0),
+	canopy_spread: UnitRange::new(7.0, 14.0),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
 const RARE_ROLLING_STORYBOOK: RollingOaksStorybook = RollingOaksStorybook {
 	height: UnitRange::new(5.0, 20.0),
-	stalk_radius: UnitRange::new(0.12, 0.32),
+	stalk_radius: UnitRange::new(0.20, 0.48),
 	canopy_spread: UnitRange::new(2.0, 6.5),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };
@@ -88,6 +102,26 @@ const ROLLING_BRAID_OAK_STICK_MIX: PaletteMix = PaletteMix::new(&[
 const ROLLING_BRAID_OAK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
 	PaletteSlot::new("olive_green", "fresh_green"),
 	PaletteSlot::new("deep_green", "yellow_green"),
+]);
+
+const RARE_TALL_ROLLING_BRAID_OAK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("gnarled_brown", "oak_bark"),
+	PaletteSlot::new("moss_bark", "dark_bark"),
+]);
+
+const RARE_TALL_ROLLING_BRAID_OAK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("dark_green", "deep_green"),
+	PaletteSlot::new("olive_green", "light_green"),
+]);
+
+const RARE_SENTINEL_ROLLING_BRAID_OAK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("wet_bark", "gnarled_brown"),
+	PaletteSlot::new("dark_bark", "moss_bark"),
+]);
+
+const RARE_SENTINEL_ROLLING_BRAID_OAK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("emerald_green", "deep_green"),
+	PaletteSlot::new("moss_green", "olive_green"),
 ]);
 
 const ROLLING_STORYBOOK_STICK_MIX: PaletteMix = PaletteMix::new(&[
@@ -103,16 +137,22 @@ const ROLLING_STORYBOOK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
 impl RollingOaksCell {
 	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
 	///
-	/// Placed weights total `2.35`; the `None` weight of `12.4` puts the placed share at
-	/// `2.35 / 14.75 ≈ 0.16`, mid RFC `DENSITY_RANGE` (`0.08..0.24`).
+	/// Placed weights total `2.55`; the `None` weight of `12.4` puts the placed share at
+	/// `2.55 / 14.95 ≈ 0.17`, mid RFC `DENSITY_RANGE` (`0.08..0.24`).
 	pub fn distribution() -> GroveDistribution<Self> {
 		let braid_oak =
-			PlacementConstraints::new(UnitRange::new(0.08, 0.72), UnitRange::new(0.0, 0.48));
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.48));
+		let tall_braid_oak =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.48));
+		let sentinel_braid_oak =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.44));
 		let storybook =
-			PlacementConstraints::new(UnitRange::new(0.08, 0.68), UnitRange::new(0.0, 0.54));
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.54));
 		GroveDistribution::new(vec![
 			GroveBucket::none(12.4),
 			GroveBucket::placed(2.0, braid_oak, Self::RollingBraidOak),
+			GroveBucket::placed(0.15, tall_braid_oak, Self::RareTallRollingBraidOak),
+			GroveBucket::placed(0.05, sentinel_braid_oak, Self::RareSentinelRollingBraidOak),
 			GroveBucket::placed(0.35, storybook, Self::RareRollingStorybook),
 		])
 	}
@@ -120,6 +160,10 @@ impl RollingOaksCell {
 	pub fn item(self) -> RollingOaksItem {
 		match self {
 			Self::RollingBraidOak => RollingOaksItem::BraidOak(&ROLLING_BRAID_OAK),
+			Self::RareTallRollingBraidOak => RollingOaksItem::BraidOak(&RARE_TALL_ROLLING_BRAID_OAK),
+			Self::RareSentinelRollingBraidOak => {
+				RollingOaksItem::BraidOak(&RARE_SENTINEL_ROLLING_BRAID_OAK)
+			}
 			Self::RareRollingStorybook => RollingOaksItem::Storybook(&RARE_ROLLING_STORYBOOK),
 		}
 	}
@@ -127,6 +171,8 @@ impl RollingOaksCell {
 	pub fn stick_palette_mix(self) -> PaletteMix {
 		match self {
 			Self::RollingBraidOak => ROLLING_BRAID_OAK_STICK_MIX,
+			Self::RareTallRollingBraidOak => RARE_TALL_ROLLING_BRAID_OAK_STICK_MIX,
+			Self::RareSentinelRollingBraidOak => RARE_SENTINEL_ROLLING_BRAID_OAK_STICK_MIX,
 			Self::RareRollingStorybook => ROLLING_STORYBOOK_STICK_MIX,
 		}
 	}
@@ -134,6 +180,8 @@ impl RollingOaksCell {
 	pub fn canopy_palette_mix(self) -> PaletteMix {
 		match self {
 			Self::RollingBraidOak => ROLLING_BRAID_OAK_CANOPY_MIX,
+			Self::RareTallRollingBraidOak => RARE_TALL_ROLLING_BRAID_OAK_CANOPY_MIX,
+			Self::RareSentinelRollingBraidOak => RARE_SENTINEL_ROLLING_BRAID_OAK_CANOPY_MIX,
 			Self::RareRollingStorybook => ROLLING_STORYBOOK_CANOPY_MIX,
 		}
 	}
@@ -152,13 +200,17 @@ mod tests {
 	#[test]
 	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
 		let dist = RollingOaksCell::distribution();
-		assert_eq!(dist.len(), 3);
+		assert_eq!(dist.len(), 5);
 		assert!(dist.buckets[0].item.is_none());
 		assert_eq!(dist.buckets[0].weight, 12.4);
 		assert_eq!(dist.buckets[1].item, Some(RollingOaksCell::RollingBraidOak));
 		assert_eq!(dist.buckets[1].weight, 2.0);
-		assert_eq!(dist.buckets[2].item, Some(RollingOaksCell::RareRollingStorybook));
-		assert_eq!(dist.buckets[2].weight, 0.35);
+		assert_eq!(dist.buckets[2].item, Some(RollingOaksCell::RareTallRollingBraidOak));
+		assert_eq!(dist.buckets[2].weight, 0.15);
+		assert_eq!(dist.buckets[3].item, Some(RollingOaksCell::RareSentinelRollingBraidOak));
+		assert_eq!(dist.buckets[3].weight, 0.05);
+		assert_eq!(dist.buckets[4].item, Some(RollingOaksCell::RareRollingStorybook));
+		assert_eq!(dist.buckets[4].weight, 0.35);
 		Ok(())
 	}
 
@@ -180,6 +232,18 @@ mod tests {
 		assert_eq!(oak.height, UnitRange::new(5.0, 20.0));
 		assert_eq!(oak.canopy_density, MODERATE_CANOPY_DENSITY);
 
+		let RollingOaksItem::BraidOak(tall) = RollingOaksCell::RareTallRollingBraidOak.item() else {
+			anyhow::bail!("expected rare tall braid oak item");
+		};
+		assert_eq!(tall.height, UnitRange::new(20.0, 32.0));
+
+		let RollingOaksItem::BraidOak(sentinel) =
+			RollingOaksCell::RareSentinelRollingBraidOak.item()
+		else {
+			anyhow::bail!("expected rare sentinel braid oak item");
+		};
+		assert_eq!(sentinel.height, UnitRange::new(28.0, 40.0));
+
 		let RollingOaksItem::Storybook(story) = RollingOaksCell::RareRollingStorybook.item() else {
 			anyhow::bail!("expected storybook item");
 		};
@@ -196,17 +260,33 @@ mod tests {
 			.iter()
 			.find(|b| b.item == Some(RollingOaksCell::RollingBraidOak))
 			.ok_or_else(|| anyhow::anyhow!("missing braid oak bucket"))?;
-		assert_eq!(braid_oak.constraints.elevation.start, 0.08);
-		assert_eq!(braid_oak.constraints.elevation.end, 0.72);
+		assert_eq!(braid_oak.constraints.elevation.start, 0.0);
+		assert_eq!(braid_oak.constraints.elevation.end, 1.0);
 		assert_eq!(braid_oak.constraints.steepness.end, 0.48);
+
+		let tall_braid_oak = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(RollingOaksCell::RareTallRollingBraidOak))
+			.ok_or_else(|| anyhow::anyhow!("missing tall braid oak bucket"))?;
+		assert_eq!(tall_braid_oak.constraints.elevation.end, 1.0);
+		assert_eq!(tall_braid_oak.constraints.steepness.end, 0.48);
+
+		let sentinel_braid_oak = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(RollingOaksCell::RareSentinelRollingBraidOak))
+			.ok_or_else(|| anyhow::anyhow!("missing sentinel braid oak bucket"))?;
+		assert_eq!(sentinel_braid_oak.constraints.elevation.end, 1.0);
+		assert_eq!(sentinel_braid_oak.constraints.steepness.end, 0.44);
 
 		let storybook = dist
 			.buckets
 			.iter()
 			.find(|b| b.item == Some(RollingOaksCell::RareRollingStorybook))
 			.ok_or_else(|| anyhow::anyhow!("missing storybook bucket"))?;
-		assert_eq!(storybook.constraints.elevation.start, 0.08);
-		assert_eq!(storybook.constraints.elevation.end, 0.68);
+		assert_eq!(storybook.constraints.elevation.start, 0.0);
+		assert_eq!(storybook.constraints.elevation.end, 1.0);
 		assert_eq!(storybook.constraints.steepness.end, 0.54);
 		Ok(())
 	}
@@ -216,7 +296,7 @@ mod tests {
 		let prepared =
 			RollingOaksCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
 		let terrain = FlatTerrainSample { elevation: 0.40, steepness: 0.50 };
-		let story_outcome = prepared.select_from(5, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
+		let story_outcome = prepared.select_from(4, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
 		match story_outcome {
 			GroveCellOutcome::Placed { variant, .. } => {
 				assert_eq!(variant, RollingOaksCell::RareRollingStorybook);
@@ -226,16 +306,23 @@ mod tests {
 		let braid_outcome = prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
 		match braid_outcome {
 			GroveCellOutcome::Placed { variant, .. } => {
-				assert_ne!(variant, RollingOaksCell::RollingBraidOak);
+				assert_eq!(variant, RollingOaksCell::RareRollingStorybook);
 			}
-			GroveCellOutcome::Empty { .. } | GroveCellOutcome::Rejected { .. } => {}
+			other => anyhow::bail!(
+				"expected storybook after braid-oak variants reject steep slope, got {other:?}"
+			),
 		}
 		Ok(())
 	}
 
 	#[test]
 	fn palette_resolves_for_all_varietals() -> Result<()> {
-		for cell in [RollingOaksCell::RollingBraidOak, RollingOaksCell::RareRollingStorybook] {
+		for cell in [
+			RollingOaksCell::RollingBraidOak,
+			RollingOaksCell::RareTallRollingBraidOak,
+			RollingOaksCell::RareSentinelRollingBraidOak,
+			RollingOaksCell::RareRollingStorybook,
+		] {
 			for (palette, label) in
 				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
 			{

--- a/maybraid/chico/groves/src/rolling_oaks.rs
+++ b/maybraid/chico/groves/src/rolling_oaks.rs
@@ -1,0 +1,265 @@
+//! Rolling Oaks — low-density open oak-country upper-canopy grove
+//! ([RFC-183 §3.4.7.5], [#349](https://github.com/ramate-io/maybraid/issues/349)).
+//!
+//! Common dry Braid Oak forms with rare Storybook accents across rolling open woodland. Forest-layer
+//! attachment remains a follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{RollingOaks, RollingOaksStd};
+
+/// Moderate sampled canopy-density band ([`0.35`, `0.65`]).
+const MODERATE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
+
+/// Authored Rolling Oaks grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`22` m). The offset range is signed and ± one cell so
+/// placements break the underlying grid instead of clustering near cell centers.
+pub fn definition() -> GroveDefinition<RollingOaksCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(22.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-22.0, 22.0),
+		),
+		distribution: RollingOaksCell::distribution(),
+	}
+}
+
+/// Ordered rolling-oaks varietals ([RFC-183 §3.4.7.5]); the explicit `None` bucket lives only in
+/// the distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RollingOaksCell {
+	RollingBraidOak,
+	RareRollingStorybook,
+}
+
+/// Typed authored geometry for one rolling-oaks varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RollingOaksItem {
+	BraidOak(&'static RollingOaksBraidOak),
+	Storybook(&'static RollingOaksStorybook),
+}
+
+/// Authored geometry ranges for one Braid Oak form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RollingOaksBraidOak {
+	pub height: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one Storybook Tree form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RollingOaksStorybook {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const ROLLING_BRAID_OAK: RollingOaksBraidOak = RollingOaksBraidOak {
+	height: UnitRange::new(5.0, 20.0),
+	canopy_spread: UnitRange::new(2.0, 7.0),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const RARE_ROLLING_STORYBOOK: RollingOaksStorybook = RollingOaksStorybook {
+	height: UnitRange::new(5.0, 20.0),
+	stalk_radius: UnitRange::new(0.12, 0.32),
+	canopy_spread: UnitRange::new(2.0, 6.5),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const ROLLING_BRAID_OAK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("oak_bark", "dry_brown"),
+	PaletteSlot::new("gray_brown", "dark_bark"),
+]);
+
+const ROLLING_BRAID_OAK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("olive_green", "fresh_green"),
+	PaletteSlot::new("deep_green", "yellow_green"),
+]);
+
+const ROLLING_STORYBOOK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("broadleaf_bark", "dry_brown"),
+	PaletteSlot::new("gray_brown", "dark_bark"),
+]);
+
+const ROLLING_STORYBOOK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("olive_green", "light_green"),
+	PaletteSlot::new("deep_green", "yellow_green"),
+]);
+
+impl RollingOaksCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `2.35`; the `None` weight of `12.4` puts the placed share at
+	/// `2.35 / 14.75 ≈ 0.16`, mid RFC `DENSITY_RANGE` (`0.08..0.24`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let braid_oak =
+			PlacementConstraints::new(UnitRange::new(0.08, 0.72), UnitRange::new(0.0, 0.48));
+		let storybook =
+			PlacementConstraints::new(UnitRange::new(0.08, 0.68), UnitRange::new(0.0, 0.54));
+		GroveDistribution::new(vec![
+			GroveBucket::none(12.4),
+			GroveBucket::placed(2.0, braid_oak, Self::RollingBraidOak),
+			GroveBucket::placed(0.35, storybook, Self::RareRollingStorybook),
+		])
+	}
+
+	pub fn item(self) -> RollingOaksItem {
+		match self {
+			Self::RollingBraidOak => RollingOaksItem::BraidOak(&ROLLING_BRAID_OAK),
+			Self::RareRollingStorybook => RollingOaksItem::Storybook(&RARE_ROLLING_STORYBOOK),
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::RollingBraidOak => ROLLING_BRAID_OAK_STICK_MIX,
+			Self::RareRollingStorybook => ROLLING_STORYBOOK_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::RollingBraidOak => ROLLING_BRAID_OAK_CANOPY_MIX,
+			Self::RareRollingStorybook => ROLLING_STORYBOOK_CANOPY_MIX,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveCellOutcome, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+	use procedural_common::NoiseParams;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = RollingOaksCell::distribution();
+		assert_eq!(dist.len(), 3);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 12.4);
+		assert_eq!(dist.buckets[1].item, Some(RollingOaksCell::RollingBraidOak));
+		assert_eq!(dist.buckets[1].weight, 2.0);
+		assert_eq!(dist.buckets[2].item, Some(RollingOaksCell::RareRollingStorybook));
+		assert_eq!(dist.buckets[2].weight, 0.35);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = RollingOaksCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.08..=0.24).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let RollingOaksItem::BraidOak(oak) = RollingOaksCell::RollingBraidOak.item() else {
+			anyhow::bail!("expected braid oak item");
+		};
+		assert_eq!(oak.height, UnitRange::new(5.0, 20.0));
+		assert_eq!(oak.canopy_density, MODERATE_CANOPY_DENSITY);
+
+		let RollingOaksItem::Storybook(story) = RollingOaksCell::RareRollingStorybook.item() else {
+			anyhow::bail!("expected storybook item");
+		};
+		assert_eq!(story.height, UnitRange::new(5.0, 20.0));
+		assert_eq!(story.canopy_density, MODERATE_CANOPY_DENSITY);
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_match_rfc() -> Result<()> {
+		let dist = RollingOaksCell::distribution();
+		let braid_oak = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(RollingOaksCell::RollingBraidOak))
+			.ok_or_else(|| anyhow::anyhow!("missing braid oak bucket"))?;
+		assert_eq!(braid_oak.constraints.elevation.start, 0.08);
+		assert_eq!(braid_oak.constraints.elevation.end, 0.72);
+		assert_eq!(braid_oak.constraints.steepness.end, 0.48);
+
+		let storybook = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(RollingOaksCell::RareRollingStorybook))
+			.ok_or_else(|| anyhow::anyhow!("missing storybook bucket"))?;
+		assert_eq!(storybook.constraints.elevation.start, 0.08);
+		assert_eq!(storybook.constraints.elevation.end, 0.68);
+		assert_eq!(storybook.constraints.steepness.end, 0.54);
+		Ok(())
+	}
+
+	#[test]
+	fn steep_slope_rejects_braid_oak_but_allows_storybook() -> Result<()> {
+		let prepared =
+			RollingOaksCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
+		let terrain = FlatTerrainSample { elevation: 0.40, steepness: 0.50 };
+		let story_outcome = prepared.select_from(5, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
+		match story_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_eq!(variant, RollingOaksCell::RareRollingStorybook);
+			}
+			other => anyhow::bail!("expected RareRollingStorybook on moderate slope, got {other:?}"),
+		}
+		let braid_outcome = prepared.select_from(1, Vec3::new(5.0, 0.40, 5.0), 1.0, &terrain);
+		match braid_outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_ne!(variant, RollingOaksCell::RollingBraidOak);
+			}
+			GroveCellOutcome::Empty { .. } | GroveCellOutcome::Rejected { .. } => {}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [RollingOaksCell::RollingBraidOak, RollingOaksCell::RareRollingStorybook] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(220.0, 1.0, 220.0));
+		let terrain = FlatTerrainSample { elevation: 0.40, steepness: 0.15 };
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/rolling_oaks/render.rs
+++ b/maybraid/chico/groves/src/rolling_oaks/render.rs
@@ -1,0 +1,381 @@
+//! [`RenderItem`] for populated Rolling Oaks groves ([#349](https://github.com/ramate-io/maybraid/issues/349)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::{BraidOakTreeSbs, StorybookTreeSbs};
+use chico_sbs_trees::braid_oak_tree::BraidOakTree;
+use chico_sbs_trees::storybook_tree::StorybookTree;
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::rolling_oaks::{
+	definition, RollingOaksBraidOak, RollingOaksCell, RollingOaksItem, RollingOaksStorybook,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Rolling Oaks instance.
+pub type RollingOaksStd = RollingOaks<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Rolling Oaks grove preview (sparse dry braid oaks with rare storybook accents).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct RollingOaks<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<RollingOaksCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for RollingOaks<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RollingOaks<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<RollingOaksCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<RollingOaksCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+fn span_fraction(canopy_spread: f32, height: f32) -> f32 {
+	(canopy_spread / height.max(0.5)).clamp(0.35, 1.20)
+}
+
+impl BuildWithNoise<BraidOakTreeSbs> for RollingOaksBraidOak {
+	fn build_with_noise(&self, noise: NoiseParams) -> BraidOakTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let _canopy_density = sample_f32(&config, self.canopy_density, 3.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = BraidOakTreeSbs::default();
+		geometry.apply_braid_preset();
+		geometry.scale.tree_height = height;
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.02);
+		geometry.canopy_noise = noise;
+		geometry
+	}
+}
+
+impl BuildWithNoise<StorybookTreeSbs> for RollingOaksStorybook {
+	fn build_with_noise(&self, noise: NoiseParams) -> StorybookTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 4.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = StorybookTreeSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.05);
+		geometry.rings.height_range = UnitRange::new(0.58, 1.0);
+		geometry.canopy_noise = noise;
+		let _ = canopy_density;
+		geometry
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for RollingOaks<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let entities = match placed.variant.item() {
+				RollingOaksItem::BraidOak(oak) => {
+					let geometry = oak.build_with_noise(build_noise);
+					let mut tree =
+						BraidOakTree::<StickM, StickS, LeafM, LeafS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.inner_leaf_material = self.leaf_material.clone();
+					tree.outer_leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.inner_leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				RollingOaksItem::Storybook(story) => {
+					let geometry = story.build_with_noise(build_noise);
+					let mut tree = StorybookTree::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+			};
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let RollingOaksItem::BraidOak(oak) = RollingOaksCell::RollingBraidOak.item() else {
+			anyhow::bail!("expected braid oak item");
+		};
+		let oak_geom = oak.build_with_noise(noise);
+		assert!(oak_geom.scale.tree_height >= oak.height.start.min(oak.height.end));
+		assert!(oak_geom.scale.tree_height <= oak.height.start.max(oak.height.end));
+
+		let RollingOaksItem::Storybook(story) = RollingOaksCell::RareRollingStorybook.item() else {
+			anyhow::bail!("expected storybook item");
+		};
+		let story_geom = story.build_with_noise(noise);
+		assert!(story_geom.scale.tree_height >= story.height.start.min(story.height.end));
+		assert!(story_geom.scale.tree_height <= story.height.start.max(story.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [RollingOaksCell::RollingBraidOak, RollingOaksCell::RareRollingStorybook] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn default_weights_yield_low_density_placements_in_preview_grid() -> Result<()> {
+		let span = DEFAULT_GROVE_EXTENT_XZ;
+		let grove = RollingOaksStd::default()
+			.with_terrain(FlatTerrainSample { elevation: 0.40, steepness: 0.15 })
+			.with_extent(GroveExtent::new(Vec3::ZERO, Vec3::new(span, 1.0, span)));
+		let cells = grove.placement_cells().len();
+		let placements = grove.placements();
+		let placed_share = placements.len() as f32 / cells as f32;
+		assert!(
+			(0.08..=0.24).contains(&placed_share),
+			"expected rolling-oaks fill, got {placed_share} ({}/{cells})",
+			placements.len()
+		);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/rolling_oaks/render.rs
+++ b/maybraid/chico/groves/src/rolling_oaks/render.rs
@@ -336,6 +336,22 @@ mod tests {
 		assert!(oak_geom.scale.tree_height >= oak.height.start.min(oak.height.end));
 		assert!(oak_geom.scale.tree_height <= oak.height.start.max(oak.height.end));
 
+		let RollingOaksItem::BraidOak(tall) = RollingOaksCell::RareTallRollingBraidOak.item() else {
+			anyhow::bail!("expected rare tall braid oak item");
+		};
+		let tall_geom = tall.build_with_noise(noise);
+		assert!(tall_geom.scale.tree_height >= tall.height.start.min(tall.height.end));
+		assert!(tall_geom.scale.tree_height <= tall.height.start.max(tall.height.end));
+
+		let RollingOaksItem::BraidOak(sentinel) =
+			RollingOaksCell::RareSentinelRollingBraidOak.item()
+		else {
+			anyhow::bail!("expected rare sentinel braid oak item");
+		};
+		let sentinel_geom = sentinel.build_with_noise(noise);
+		assert!(sentinel_geom.scale.tree_height >= sentinel.height.start.min(sentinel.height.end));
+		assert!(sentinel_geom.scale.tree_height <= sentinel.height.start.max(sentinel.height.end));
+
 		let RollingOaksItem::Storybook(story) = RollingOaksCell::RareRollingStorybook.item() else {
 			anyhow::bail!("expected storybook item");
 		};
@@ -347,7 +363,12 @@ mod tests {
 
 	#[test]
 	fn palette_resolves_for_all_varietals() -> Result<()> {
-		for cell in [RollingOaksCell::RollingBraidOak, RollingOaksCell::RareRollingStorybook] {
+		for cell in [
+			RollingOaksCell::RollingBraidOak,
+			RollingOaksCell::RareTallRollingBraidOak,
+			RollingOaksCell::RareSentinelRollingBraidOak,
+			RollingOaksCell::RareRollingStorybook,
+		] {
 			for (palette, label) in
 				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
 			{

--- a/maybraid/chico/groves/src/storytellers.rs
+++ b/maybraid/chico/groves/src/storytellers.rs
@@ -94,7 +94,7 @@ pub struct StorytellersTorch {
 
 const COLORFUL_STORYBOOK: StorytellersStorybook = StorytellersStorybook {
 	height: UnitRange::new(10.0, 30.0),
-	stalk_radius: UnitRange::new(0.18, 0.42),
+	stalk_radius: UnitRange::new(0.24, 0.55),
 	canopy_spread: UnitRange::new(3.0, 8.0),
 	canopy_density: DENSE_CANOPY_DENSITY,
 };
@@ -106,14 +106,14 @@ const COLORFUL_BRAID_OAK: StorytellersBraidOak = StorytellersBraidOak {
 
 const BRIGHT_CANOPY_STORYBOOK: StorytellersStorybook = StorytellersStorybook {
 	height: UnitRange::new(10.0, 26.0),
-	stalk_radius: UnitRange::new(0.16, 0.38),
+	stalk_radius: UnitRange::new(0.22, 0.50),
 	canopy_spread: UnitRange::new(2.5, 7.0),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };
 
 const PINK_LANTERN_STORYBOOK: StorytellersStorybook = StorytellersStorybook {
 	height: UnitRange::new(8.0, 18.0),
-	stalk_radius: UnitRange::new(0.14, 0.32),
+	stalk_radius: UnitRange::new(0.20, 0.44),
 	canopy_spread: UnitRange::new(2.0, 5.5),
 	canopy_density: DENSE_CANOPY_DENSITY,
 };
@@ -125,14 +125,14 @@ const RED_FESTIVAL_BRAID_OAK: StorytellersBraidOak = StorytellersBraidOak {
 
 const PURPLE_CROWN_STORYBOOK: StorytellersStorybook = StorytellersStorybook {
 	height: UnitRange::new(14.0, 30.0),
-	stalk_radius: UnitRange::new(0.20, 0.45),
+	stalk_radius: UnitRange::new(0.28, 0.58),
 	canopy_spread: UnitRange::new(3.5, 9.0),
 	canopy_density: SPARSE_CANOPY_DENSITY,
 };
 
 const BLUE_MOON_STORYBOOK: StorytellersStorybook = StorytellersStorybook {
 	height: UnitRange::new(12.0, 22.0),
-	stalk_radius: UnitRange::new(0.16, 0.36),
+	stalk_radius: UnitRange::new(0.22, 0.48),
 	canopy_spread: UnitRange::new(2.5, 6.5),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/groves/src/strange_oasis.rs
+++ b/maybraid/chico/groves/src/strange_oasis.rs
@@ -103,7 +103,7 @@ const RED_TORCH_ACCENT: StrangeOasisTorch = StrangeOasisTorch {
 
 const OASIS_STORYBOOK: StrangeOasisStorybook = StrangeOasisStorybook {
 	height: UnitRange::new(4.0, 6.0),
-	stalk_radius: UnitRange::new(0.14, 0.24),
+	stalk_radius: UnitRange::new(0.20, 0.32),
 	canopy_spread: UnitRange::new(1.6, 3.6),
 	canopy_density: SPARSE_TO_MODERATE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/groves/src/temperate_lower_massives.rs
+++ b/maybraid/chico/groves/src/temperate_lower_massives.rs
@@ -88,7 +88,7 @@ const LOWER_MASSIVE_BRAID_OAK: TemperateLowerMassivesBraidOak = TemperateLowerMa
 
 const LOWER_MASSIVE_STORYBOOK: TemperateLowerMassivesStorybook = TemperateLowerMassivesStorybook {
 	height: UnitRange::new(8.0, 20.0),
-	stalk_radius: UnitRange::new(0.28, 0.55),
+	stalk_radius: UnitRange::new(0.36, 0.72),
 	canopy_spread: UnitRange::new(3.5, 8.0),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/groves/src/temperate_massives.rs
+++ b/maybraid/chico/groves/src/temperate_massives.rs
@@ -1,0 +1,320 @@
+//! Temperate Massives — low-density giant broadleaf upper-canopy grove
+//! ([RFC-183 §3.4.7.3], [#345](https://github.com/ramate-io/maybraid/issues/345)).
+//!
+//! Enormous Braid Oak, Storybook Tree, and rare Rory's Head-trained skyline forms above temperate
+//! lower massives. Forest-layer attachment remains a follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{TemperateMassives, TemperateMassivesStd};
+
+/// Moderate sampled canopy-density band ([`0.35`, `0.65`]).
+const MODERATE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.35, 0.65);
+/// Dense sampled canopy-density band ([`0.50`, `0.85`]).
+const DENSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.50, 0.85);
+
+/// Authored Temperate Massives grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`49` m). The offset range is signed and ± one cell so
+/// placements break the underlying grid instead of clustering near cell centers.
+pub fn definition() -> GroveDefinition<TemperateMassivesCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(49.0),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-49.0, 49.0),
+		),
+		distribution: TemperateMassivesCell::distribution(),
+	}
+}
+
+/// Ordered temperate-massive varietals ([RFC-183 §3.4.7.3]); the explicit `None` bucket lives only
+/// in the distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemperateMassivesCell {
+	MassiveBraidOak,
+	MassiveStorybook,
+	RareMassiveRory,
+}
+
+/// Typed authored geometry for one temperate-massive varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TemperateMassivesItem {
+	BraidOak(&'static TemperateMassivesBraidOak),
+	Storybook(&'static TemperateMassivesStorybook),
+	Rory(&'static TemperateMassivesRory),
+}
+
+/// Authored geometry ranges for one Braid Oak form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemperateMassivesBraidOak {
+	pub height: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one Storybook Tree form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemperateMassivesStorybook {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+/// Authored geometry ranges for one rare Rory's Head-trained form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemperateMassivesRory {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const MASSIVE_BRAID_OAK: TemperateMassivesBraidOak = TemperateMassivesBraidOak {
+	height: UnitRange::new(28.0, 80.0),
+	canopy_spread: UnitRange::new(8.0, 20.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const MASSIVE_STORYBOOK: TemperateMassivesStorybook = TemperateMassivesStorybook {
+	height: UnitRange::new(35.0, 170.0),
+	stalk_radius: UnitRange::new(0.5, 1.2),
+	canopy_spread: UnitRange::new(12.0, 35.0),
+	canopy_density: DENSE_CANOPY_DENSITY,
+};
+
+const RARE_MASSIVE_RORY: TemperateMassivesRory = TemperateMassivesRory {
+	height: UnitRange::new(50.0, 200.0),
+	stalk_radius: UnitRange::new(0.45, 1.80),
+	canopy_spread: UnitRange::new(6.0, 14.0),
+	canopy_density: MODERATE_CANOPY_DENSITY,
+};
+
+const BRAID_OAK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("oak_bark", "dark_bark"),
+	PaletteSlot::new("gray_brown", "moss_bark"),
+]);
+
+const BRAID_OAK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("deep_green", "fresh_green"),
+	PaletteSlot::new("dark_green", "light_green"),
+]);
+
+const STORYBOOK_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("broadleaf_bark", "brown_bark"),
+	PaletteSlot::new("gray_brown", "dark_bark"),
+]);
+
+const STORYBOOK_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("broadleaf_green", "light_green"),
+	PaletteSlot::new("deep_green", "yellow_green"),
+]);
+
+const RORY_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("weathered_bark", "dark_bark"),
+	PaletteSlot::new("red_brown", "gray_brown"),
+]);
+
+const RORY_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("deep_green", "fresh_green"),
+	PaletteSlot::new("yellow_green", "light_green"),
+]);
+
+impl TemperateMassivesCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weights total `4.35`; the `None` weight of `24.6` puts the placed share at
+	/// `4.35 / 28.95 ≈ 0.15`, mid RFC `DENSITY_RANGE` (`0.08..0.22`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let braid_oak =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.44));
+		let storybook =
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.50));
+		let rory = PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.60));
+		GroveDistribution::new(vec![
+			GroveBucket::none(24.6),
+			GroveBucket::placed(2.0, braid_oak, Self::MassiveBraidOak),
+			GroveBucket::placed(2.0, storybook, Self::MassiveStorybook),
+			GroveBucket::placed(0.35, rory, Self::RareMassiveRory),
+		])
+	}
+
+	pub fn item(self) -> TemperateMassivesItem {
+		match self {
+			Self::MassiveBraidOak => TemperateMassivesItem::BraidOak(&MASSIVE_BRAID_OAK),
+			Self::MassiveStorybook => TemperateMassivesItem::Storybook(&MASSIVE_STORYBOOK),
+			Self::RareMassiveRory => TemperateMassivesItem::Rory(&RARE_MASSIVE_RORY),
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::MassiveBraidOak => BRAID_OAK_STICK_MIX,
+			Self::MassiveStorybook => STORYBOOK_STICK_MIX,
+			Self::RareMassiveRory => RORY_STICK_MIX,
+		}
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		match self {
+			Self::MassiveBraidOak => BRAID_OAK_CANOPY_MIX,
+			Self::MassiveStorybook => STORYBOOK_CANOPY_MIX,
+			Self::RareMassiveRory => RORY_CANOPY_MIX,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{
+		FlatTerrainSample, ForestGroveBiases, Grove, GroveCellOutcome, GroveExtent,
+	};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+	use procedural_common::NoiseParams;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = TemperateMassivesCell::distribution();
+		assert_eq!(dist.len(), 4);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 24.6);
+		assert_eq!(dist.buckets[1].item, Some(TemperateMassivesCell::MassiveBraidOak));
+		assert_eq!(dist.buckets[1].weight, 2.0);
+		assert_eq!(dist.buckets[2].item, Some(TemperateMassivesCell::MassiveStorybook));
+		assert_eq!(dist.buckets[2].weight, 2.0);
+		assert_eq!(dist.buckets[3].item, Some(TemperateMassivesCell::RareMassiveRory));
+		assert_eq!(dist.buckets[3].weight, 0.35);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = TemperateMassivesCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.08..=0.22).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let TemperateMassivesItem::BraidOak(oak) = TemperateMassivesCell::MassiveBraidOak.item()
+		else {
+			anyhow::bail!("expected braid oak item");
+		};
+		assert_eq!(oak.height, UnitRange::new(28.0, 80.0));
+		assert_eq!(oak.canopy_spread, UnitRange::new(8.0, 20.0));
+		assert_eq!(oak.canopy_density, DENSE_CANOPY_DENSITY);
+
+		let TemperateMassivesItem::Storybook(story) =
+			TemperateMassivesCell::MassiveStorybook.item()
+		else {
+			anyhow::bail!("expected storybook item");
+		};
+		assert_eq!(story.height, UnitRange::new(35.0, 170.0));
+		assert_eq!(story.stalk_radius, UnitRange::new(0.5, 1.2));
+		assert_eq!(story.canopy_spread, UnitRange::new(12.0, 35.0));
+		assert_eq!(story.canopy_density, DENSE_CANOPY_DENSITY);
+
+		let TemperateMassivesItem::Rory(rory) = TemperateMassivesCell::RareMassiveRory.item() else {
+			anyhow::bail!("expected rory item");
+		};
+		assert_eq!(rory.height, UnitRange::new(50.0, 200.0));
+		assert_eq!(rory.canopy_spread, UnitRange::new(6.0, 14.0));
+		assert_eq!(rory.canopy_density, MODERATE_CANOPY_DENSITY);
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_use_full_elevation_and_rfc_steepness() -> Result<()> {
+		let dist = TemperateMassivesCell::distribution();
+		for bucket in dist.buckets.iter().filter(|b| b.item.is_some()) {
+			assert_eq!(bucket.constraints.elevation.start, 0.0);
+			assert_eq!(bucket.constraints.elevation.end, 1.0);
+		}
+		let braid_oak = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(TemperateMassivesCell::MassiveBraidOak))
+			.ok_or_else(|| anyhow::anyhow!("missing braid oak bucket"))?;
+		assert_eq!(braid_oak.constraints.steepness.end, 0.44);
+
+		let storybook = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(TemperateMassivesCell::MassiveStorybook))
+			.ok_or_else(|| anyhow::anyhow!("missing storybook bucket"))?;
+		assert_eq!(storybook.constraints.steepness.end, 0.50);
+
+		let rory = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(TemperateMassivesCell::RareMassiveRory))
+			.ok_or_else(|| anyhow::anyhow!("missing rory bucket"))?;
+		assert_eq!(rory.constraints.steepness.end, 0.60);
+		Ok(())
+	}
+
+	#[test]
+	fn steep_slope_rejects_braid_oak_but_allows_rory() -> Result<()> {
+		let prepared =
+			TemperateMassivesCell::distribution().prepare(0.0, 0.0, NoiseParams::default(), Vec3::ZERO);
+		let terrain = FlatTerrainSample { elevation: 0.30, steepness: 0.55 };
+		let outcome = prepared.select_from(8, Vec3::new(5.0, 0.30, 5.0), 1.0, &terrain);
+		match outcome {
+			GroveCellOutcome::Placed { variant, .. } => {
+				assert_ne!(variant, TemperateMassivesCell::MassiveBraidOak);
+				assert_ne!(variant, TemperateMassivesCell::MassiveStorybook);
+			}
+			GroveCellOutcome::Empty { .. } | GroveCellOutcome::Rejected { .. } => {}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			TemperateMassivesCell::MassiveBraidOak,
+			TemperateMassivesCell::MassiveStorybook,
+			TemperateMassivesCell::RareMassiveRory,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(400.0, 1.0, 400.0));
+		let terrain = FlatTerrainSample { elevation: 0.35, steepness: 0.15 };
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/temperate_massives.rs
+++ b/maybraid/chico/groves/src/temperate_massives.rs
@@ -88,7 +88,7 @@ const MASSIVE_BRAID_OAK: TemperateMassivesBraidOak = TemperateMassivesBraidOak {
 
 const MASSIVE_STORYBOOK: TemperateMassivesStorybook = TemperateMassivesStorybook {
 	height: UnitRange::new(35.0, 170.0),
-	stalk_radius: UnitRange::new(0.5, 1.2),
+	stalk_radius: UnitRange::new(3.0, 9.0),
 	canopy_spread: UnitRange::new(12.0, 35.0),
 	canopy_density: DENSE_CANOPY_DENSITY,
 };
@@ -225,7 +225,7 @@ mod tests {
 			anyhow::bail!("expected storybook item");
 		};
 		assert_eq!(story.height, UnitRange::new(35.0, 170.0));
-		assert_eq!(story.stalk_radius, UnitRange::new(0.5, 1.2));
+		assert_eq!(story.stalk_radius, UnitRange::new(3.0, 9.0));
 		assert_eq!(story.canopy_spread, UnitRange::new(12.0, 35.0));
 		assert_eq!(story.canopy_density, DENSE_CANOPY_DENSITY);
 

--- a/maybraid/chico/groves/src/temperate_massives/render.rs
+++ b/maybraid/chico/groves/src/temperate_massives/render.rs
@@ -1,0 +1,465 @@
+//! [`RenderItem`] for populated Temperate Massives groves ([#345](https://github.com/ramate-io/maybraid/issues/345)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::{BraidOakTreeSbs, RorysHeadTrainedSbs, StorybookTreeSbs};
+use chico_sbs_trees::braid_oak_tree::BraidOakTree;
+use chico_sbs_trees::rorys_head_trained::RorysHeadTrained;
+use chico_sbs_trees::storybook_tree::StorybookTree;
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+use crate::temperate_massives::{
+	definition, TemperateMassivesBraidOak, TemperateMassivesCell, TemperateMassivesItem,
+	TemperateMassivesRory, TemperateMassivesStorybook,
+};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Temperate Massives instance.
+pub type TemperateMassivesStd = TemperateMassives<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Temperate Massives grove preview (giant broadleaf upper-canopy skyline trees).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct TemperateMassives<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees and banyans",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<TemperateMassivesCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for TemperateMassives<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> TemperateMassives<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<TemperateMassivesCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<TemperateMassivesCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+fn span_fraction(canopy_spread: f32, height: f32) -> f32 {
+	(canopy_spread / height.max(0.5)).clamp(0.35, 1.20)
+}
+
+/// Looser ring spacing than understory mini forms.
+const MASSIVE_RING_SPACING_SCALE: f32 = 1.25;
+const MASSIVE_ANCHORS_PER_RING: u32 = 5;
+
+fn massive_ring_spacing(base: f32) -> f32 {
+	base * MASSIVE_RING_SPACING_SCALE
+}
+
+impl BuildWithNoise<BraidOakTreeSbs> for TemperateMassivesBraidOak {
+	fn build_with_noise(&self, noise: NoiseParams) -> BraidOakTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height = sample_f32(&config, self.height, 1.0).max(28.0);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = BraidOakTreeSbs::default();
+		geometry.apply_braid_preset();
+		geometry.scale.tree_height = height;
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.02);
+		geometry.canopy_noise = noise;
+		geometry
+	}
+}
+
+impl BuildWithNoise<StorybookTreeSbs> for TemperateMassivesStorybook {
+	fn build_with_noise(&self, noise: NoiseParams) -> StorybookTreeSbs {
+		let config = NoiseConfig::new(noise);
+		let height = sample_f32(&config, self.height, 1.0).max(35.0);
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+		let canopy_density = sample_f32(&config, self.canopy_density, 4.0);
+		let span = span_fraction(canopy_spread, height);
+
+		let mut geometry = StorybookTreeSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.rings.spacing = massive_ring_spacing(geometry.rings.spacing);
+		geometry.rings.anchors_per_ring =
+			MASSIVE_ANCHORS_PER_RING + (canopy_density * 2.0).round() as u32;
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.82, span * 1.05);
+		geometry.rings.height_range = UnitRange::new(0.58, 1.0);
+		geometry.canopy_noise = noise;
+		geometry
+	}
+}
+
+impl BuildWithNoise<RorysHeadTrainedSbs> for TemperateMassivesRory {
+	fn build_with_noise(&self, noise: NoiseParams) -> RorysHeadTrainedSbs {
+		let config = NoiseConfig::new(noise);
+		let height = sample_f32(&config, self.height, 1.0).max(50.0);
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+
+		let mut geometry = RorysHeadTrainedSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.canopy_noise = noise;
+		let span = span_fraction(canopy_spread, height);
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.95, span * 1.15);
+		geometry
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for TemperateMassives<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let entities = match placed.variant.item() {
+				TemperateMassivesItem::BraidOak(oak) => {
+					let geometry = oak.build_with_noise(build_noise);
+					let mut tree =
+						BraidOakTree::<StickM, StickS, LeafM, LeafS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.inner_leaf_material = self.leaf_material.clone();
+					tree.outer_leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.inner_leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				TemperateMassivesItem::Storybook(story) => {
+					let geometry = story.build_with_noise(build_noise);
+					let mut tree = StorybookTree::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+				TemperateMassivesItem::Rory(rory) => {
+					let geometry = rory.build_with_noise(build_noise);
+					let mut tree = RorysHeadTrained::<StickM, StickS, LeafM, LeafS>::default();
+					tree.geometry = geometry;
+					tree.stick_material = self.stick_material.clone();
+					tree.leaf_material = self.leaf_material.clone();
+					tree.stick_surface_noise =
+						placement_noise(self.stick_surface_noise, placed.position);
+					tree.leaf_surface_noise = foliage_noise;
+					let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+					patch_spawned_leaf_material::<StickM>(
+						&entities,
+						placed.variant.stick_palette_mix(),
+						stick_seed,
+						commands,
+					);
+					patch_spawned_leaf_material::<LeafM>(
+						&entities,
+						placed.variant.canopy_palette_mix(),
+						canopy_seed,
+						commands,
+					);
+					entities
+				}
+			};
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn tree_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let TemperateMassivesItem::BraidOak(oak) = TemperateMassivesCell::MassiveBraidOak.item()
+		else {
+			anyhow::bail!("expected braid oak item");
+		};
+		let oak_geom = oak.build_with_noise(noise);
+		assert!(oak_geom.scale.tree_height >= oak.height.start.min(oak.height.end));
+		assert!(oak_geom.scale.tree_height <= oak.height.start.max(oak.height.end));
+
+		let TemperateMassivesItem::Storybook(story) =
+			TemperateMassivesCell::MassiveStorybook.item()
+		else {
+			anyhow::bail!("expected storybook item");
+		};
+		let story_geom = story.build_with_noise(noise);
+		assert!(story_geom.scale.tree_height >= story.height.start.min(story.height.end));
+		assert!(story_geom.scale.tree_height <= story.height.start.max(story.height.end));
+
+		let TemperateMassivesItem::Rory(rory) = TemperateMassivesCell::RareMassiveRory.item() else {
+			anyhow::bail!("expected rory item");
+		};
+		let rory_geom = rory.build_with_noise(noise);
+		assert!(rory_geom.scale.tree_height >= rory.height.start.min(rory.height.end));
+		assert!(rory_geom.scale.tree_height <= rory.height.start.max(rory.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [
+			TemperateMassivesCell::MassiveBraidOak,
+			TemperateMassivesCell::MassiveStorybook,
+			TemperateMassivesCell::RareMassiveRory,
+		] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn with_resolved_placements_skips_live_selection() -> Result<()> {
+		let placement = GrovePlacedCell::new(
+			TemperateMassivesCell::MassiveStorybook,
+			Vec3::new(1.0, 0.0, 2.0),
+			1.0,
+		);
+		let item = TemperateMassivesStd::with_resolved_placements(
+			vec![placement.clone()],
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			GroveSkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements(), vec![placement]);
+		Ok(())
+	}
+
+	#[test]
+	fn default_weights_yield_low_density_placements_in_preview_grid() -> Result<()> {
+		let span = 400.0;
+		let grove = TemperateMassivesStd::default()
+			.with_terrain(FlatTerrainSample { elevation: 0.35, steepness: 0.15 })
+			.with_extent(GroveExtent::new(Vec3::ZERO, Vec3::new(span, 1.0, span)));
+		let cells = grove.placement_cells().len();
+		let placements = grove.placements();
+		let placed_share = placements.len() as f32 / cells as f32;
+		assert!(
+			(0.08..=0.22).contains(&placed_share),
+			"expected temperate-massives fill, got {placed_share} ({}/{cells})",
+			placements.len()
+		);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/unending_jungle.rs
+++ b/maybraid/chico/groves/src/unending_jungle.rs
@@ -137,7 +137,7 @@ const SMALL_SOPE_BANYAN: UnendingJungleBanyan = UnendingJungleBanyan {
 
 const LOWER_STORYBOOK: UnendingJungleStorybook = UnendingJungleStorybook {
 	height: UnitRange::new(3.0, 5.0),
-	stalk_radius: UnitRange::new(0.12, 0.20),
+	stalk_radius: UnitRange::new(0.18, 0.28),
 	canopy_spread: UnitRange::new(1.5, 3.5),
 	canopy_density: MODERATE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/groves/src/vineyard.rs
+++ b/maybraid/chico/groves/src/vineyard.rs
@@ -1,0 +1,188 @@
+//! Vineyard — moderate-density cultivated Rory-trained vine upper-canopy grove
+//! ([RFC-183 §3.4.7.8], [#355](https://github.com/ramate-io/maybraid/issues/355)).
+//!
+//! Low trained-vine rows with very tight cell offset and grape-like palettes. Forest-layer
+//! attachment remains a follow-up.
+
+use bevy_math::Vec2;
+use procedural_common::UnitRange;
+
+use crate::grove::{
+	GroveBucket, GroveDefinition, GroveDistribution, GrovePlacementRanges, PaletteMix, PaletteSlot,
+	PlacementConstraints,
+};
+
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "render")]
+pub use render::{Vineyard, VineyardStd};
+
+/// Sparse sampled canopy-density band ([`0.0`, `0.35`]).
+const SPARSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.0, 0.35);
+
+/// Authored Vineyard grove definition.
+///
+/// Cell footprint sits at the RFC midpoint (`4.5` m). Offset stays very tight for row-like
+/// cultivated placement.
+pub fn definition() -> GroveDefinition<VineyardCell> {
+	GroveDefinition {
+		cell_extent_xz: Vec2::splat(4.5),
+		placement: GrovePlacementRanges::new(
+			UnitRange::new(0.85, 1.15),
+			UnitRange::new(-0.6, 0.6),
+		),
+		distribution: VineyardCell::distribution(),
+	}
+}
+
+/// Ordered vineyard varietals ([RFC-183 §3.4.7.8]); the explicit `None` bucket lives only in the
+/// distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VineyardCell {
+	TrainedVineRory,
+}
+
+/// Typed authored geometry for one vineyard varietal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VineyardItem {
+	Rory(&'static VineyardRory),
+}
+
+/// Authored geometry ranges for one trained-vine Rory form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VineyardRory {
+	pub height: UnitRange,
+	pub stalk_radius: UnitRange,
+	pub canopy_spread: UnitRange,
+	pub canopy_density: UnitRange,
+}
+
+const TRAINED_VINE_RORY: VineyardRory = VineyardRory {
+	height: UnitRange::new(1.5, 3.0),
+	stalk_radius: UnitRange::new(0.045, 0.090),
+	canopy_spread: UnitRange::new(1.0, 2.4),
+	canopy_density: SPARSE_CANOPY_DENSITY,
+};
+
+const VINE_STICK_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("vine_bark", "red_brown"),
+	PaletteSlot::new("weathered_bark", "gray_brown"),
+]);
+
+const VINE_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
+	PaletteSlot::new("grape_green", "fresh_green"),
+	PaletteSlot::new("deep_green", "yellow_green"),
+]);
+
+impl VineyardCell {
+	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
+	///
+	/// Placed weight `1.0`; the `None` weight of `2.5` puts the placed share at
+	/// `1.0 / 3.5 ≈ 0.29`, low RFC `DENSITY_RANGE` (`0.28..0.50`).
+	pub fn distribution() -> GroveDistribution<Self> {
+		let trained_vine =
+			PlacementConstraints::new(UnitRange::new(0.04, 0.68), UnitRange::new(0.0, 0.34));
+		GroveDistribution::new(vec![
+			GroveBucket::none(2.5),
+			GroveBucket::placed(1.0, trained_vine, Self::TrainedVineRory),
+		])
+	}
+
+	pub fn item(self) -> VineyardItem {
+		match self {
+			Self::TrainedVineRory => VineyardItem::Rory(&TRAINED_VINE_RORY),
+		}
+	}
+
+	pub fn stick_palette_mix(self) -> PaletteMix {
+		VINE_STICK_MIX
+	}
+
+	pub fn canopy_palette_mix(self) -> PaletteMix {
+		VINE_CANOPY_MIX
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::grove::{FlatTerrainSample, ForestGroveBiases, Grove, GroveExtent};
+	use anyhow::Result;
+	use bevy_math::Vec3;
+
+	#[test]
+	fn distribution_matches_rfc_order_and_weights() -> Result<()> {
+		let dist = VineyardCell::distribution();
+		assert_eq!(dist.len(), 2);
+		assert!(dist.buckets[0].item.is_none());
+		assert_eq!(dist.buckets[0].weight, 2.5);
+		assert_eq!(dist.buckets[1].item, Some(VineyardCell::TrainedVineRory));
+		assert_eq!(dist.buckets[1].weight, 1.0);
+		Ok(())
+	}
+
+	#[test]
+	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+		let dist = VineyardCell::distribution();
+		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
+		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
+		let share = placed / total;
+		assert!((0.28..=0.50).contains(&share), "placed share {share} outside RFC density");
+		Ok(())
+	}
+
+	#[test]
+	fn geometry_follows_authored_bands() -> Result<()> {
+		let VineyardItem::Rory(vine) = VineyardCell::TrainedVineRory.item() else {
+			anyhow::bail!("expected trained vine rory item");
+		};
+		assert_eq!(vine.height, UnitRange::new(1.5, 3.0));
+		assert_eq!(vine.canopy_spread, UnitRange::new(1.0, 2.4));
+		assert_eq!(vine.canopy_density, SPARSE_CANOPY_DENSITY);
+		Ok(())
+	}
+
+	#[test]
+	fn placement_constraints_match_rfc() -> Result<()> {
+		let dist = VineyardCell::distribution();
+		let vine = dist
+			.buckets
+			.iter()
+			.find(|b| b.item == Some(VineyardCell::TrainedVineRory))
+			.ok_or_else(|| anyhow::anyhow!("missing trained vine bucket"))?;
+		assert_eq!(vine.constraints.elevation.start, 0.04);
+		assert_eq!(vine.constraints.elevation.end, 0.68);
+		assert_eq!(vine.constraints.steepness.end, 0.34);
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [VineyardCell::TrainedVineRory] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn populated_grove_is_deterministic_and_non_empty() -> Result<()> {
+		let noise = crate::grove::GroveFrontend::default().noise;
+		let grove = Grove::assemble(definition(), ForestGroveBiases::default(), noise, Vec3::ZERO);
+		let extent = GroveExtent::new(Vec3::ZERO, Vec3::new(80.0, 1.0, 80.0));
+		let terrain = FlatTerrainSample { elevation: 0.35, steepness: 0.12 };
+		let a = grove.populate(&extent, &terrain);
+		let b = grove.populate(&extent, &terrain);
+		assert_eq!(a, b);
+		assert!(!a.is_empty());
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/vineyard.rs
+++ b/maybraid/chico/groves/src/vineyard.rs
@@ -1,4 +1,4 @@
-//! Vineyard — moderate-density cultivated Rory-trained vine upper-canopy grove
+//! Vineyard — high-density cultivated Rory-trained vine upper-canopy grove
 //! ([RFC-183 §3.4.7.8], [#355](https://github.com/ramate-io/maybraid/issues/355)).
 //!
 //! Low trained-vine rows with very tight cell offset and grape-like palettes. Forest-layer
@@ -22,15 +22,12 @@ const SPARSE_CANOPY_DENSITY: UnitRange = UnitRange::new(0.0, 0.35);
 
 /// Authored Vineyard grove definition.
 ///
-/// Cell footprint sits at the RFC midpoint (`4.5` m). Offset stays very tight for row-like
-/// cultivated placement.
+/// Cell footprint sits at the RFC midpoint (`4.5` m). Placements stay on cell centroids with only
+/// ±`0.5` m horizontal jitter for regular vine rows.
 pub fn definition() -> GroveDefinition<VineyardCell> {
 	GroveDefinition {
 		cell_extent_xz: Vec2::splat(4.5),
-		placement: GrovePlacementRanges::new(
-			UnitRange::new(0.85, 1.15),
-			UnitRange::new(-0.6, 0.6),
-		),
+		placement: GrovePlacementRanges::new(UnitRange::new(1.0, 1.0), UnitRange::new(-0.5, 0.5)),
 		distribution: VineyardCell::distribution(),
 	}
 }
@@ -74,17 +71,21 @@ const VINE_CANOPY_MIX: PaletteMix = PaletteMix::new(&[
 	PaletteSlot::new("deep_green", "yellow_green"),
 ]);
 
+/// Explicit `None` weight so ~`95%` of cells receive a vine (`0.05` empty vs `0.95` placed).
+const CULTIVATED_EMPTY_WEIGHT: f32 = 0.05;
+const CULTIVATED_PLACED_WEIGHT: f32 = 0.95;
+
 impl VineyardCell {
 	/// Authored ordered distribution: explicit `None`, then variants in declaration order.
 	///
-	/// Placed weight `1.0`; the `None` weight of `2.5` puts the placed share at
-	/// `1.0 / 3.5 ≈ 0.29`, low RFC `DENSITY_RANGE` (`0.28..0.50`).
+	/// `None` weight `0.05` against placed weight `0.95` yields a `0.95` placed share for
+	/// regular row planting.
 	pub fn distribution() -> GroveDistribution<Self> {
 		let trained_vine =
-			PlacementConstraints::new(UnitRange::new(0.04, 0.68), UnitRange::new(0.0, 0.34));
+			PlacementConstraints::new(UnitRange::new(0.0, 1.0), UnitRange::new(0.0, 0.34));
 		GroveDistribution::new(vec![
-			GroveBucket::none(2.5),
-			GroveBucket::placed(1.0, trained_vine, Self::TrainedVineRory),
+			GroveBucket::none(CULTIVATED_EMPTY_WEIGHT),
+			GroveBucket::placed(CULTIVATED_PLACED_WEIGHT, trained_vine, Self::TrainedVineRory),
 		])
 	}
 
@@ -115,19 +116,30 @@ mod tests {
 		let dist = VineyardCell::distribution();
 		assert_eq!(dist.len(), 2);
 		assert!(dist.buckets[0].item.is_none());
-		assert_eq!(dist.buckets[0].weight, 2.5);
+		assert_eq!(dist.buckets[0].weight, CULTIVATED_EMPTY_WEIGHT);
 		assert_eq!(dist.buckets[1].item, Some(VineyardCell::TrainedVineRory));
-		assert_eq!(dist.buckets[1].weight, 1.0);
+		assert_eq!(dist.buckets[1].weight, CULTIVATED_PLACED_WEIGHT);
 		Ok(())
 	}
 
 	#[test]
-	fn placed_share_sits_in_rfc_density_range() -> Result<()> {
+	fn placed_share_targets_cultivated_fill() -> Result<()> {
 		let dist = VineyardCell::distribution();
 		let total: f32 = dist.buckets.iter().map(|b| b.weight).sum();
 		let placed: f32 = dist.buckets.iter().filter(|b| b.item.is_some()).map(|b| b.weight).sum();
 		let share = placed / total;
-		assert!((0.28..=0.50).contains(&share), "placed share {share} outside RFC density");
+		assert!(
+			(0.94..=0.96).contains(&share),
+			"placed share {share} outside cultivated ~95% target"
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn placement_uses_tight_centroid_offset_and_uniform_scale() -> Result<()> {
+		let def = definition();
+		assert_eq!(def.placement.offset, UnitRange::new(-0.5, 0.5));
+		assert_eq!(def.placement.scale, UnitRange::new(1.0, 1.0));
 		Ok(())
 	}
 
@@ -143,15 +155,15 @@ mod tests {
 	}
 
 	#[test]
-	fn placement_constraints_match_rfc() -> Result<()> {
+	fn placement_constraints_use_full_elevation_and_rfc_steepness() -> Result<()> {
 		let dist = VineyardCell::distribution();
 		let vine = dist
 			.buckets
 			.iter()
 			.find(|b| b.item == Some(VineyardCell::TrainedVineRory))
 			.ok_or_else(|| anyhow::anyhow!("missing trained vine bucket"))?;
-		assert_eq!(vine.constraints.elevation.start, 0.04);
-		assert_eq!(vine.constraints.elevation.end, 0.68);
+		assert_eq!(vine.constraints.elevation.start, 0.0);
+		assert_eq!(vine.constraints.elevation.end, 1.0);
 		assert_eq!(vine.constraints.steepness.end, 0.34);
 		Ok(())
 	}

--- a/maybraid/chico/groves/src/vineyard/render.rs
+++ b/maybraid/chico/groves/src/vineyard/render.rs
@@ -1,0 +1,319 @@
+//! [`RenderItem`] for populated Vineyard groves ([#355](https://github.com/ramate-io/maybraid/issues/355)).
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use chico_sbs_geometry::RorysHeadTrainedSbs;
+use chico_sbs_trees::rorys_head_trained::RorysHeadTrained;
+use chico_vegetation_shaders::ChicoStickMaterial;
+use clap::Args;
+use procedural_common::{
+	noise_params_from_scalar_str, BuildWithNoise, NoiseConfig, NoiseParams, UnitRange,
+};
+use render_item::{CascadeChunk, RenderItem};
+
+use crate::grove::{
+	patch_spawned_leaf_material, placement_noise, FlatTerrainSample, GroveExtent, GroveFrontend,
+	GrovePlacedCell, TerrainSample, WithPalette, DEFAULT_GROVE_EXTENT_XZ,
+};
+use crate::skipped_mesh_material::{
+	SkippedLeafMeshMaterial, SkippedStickMeshMaterial as GroveSkippedStickMeshMaterial,
+};
+use crate::vineyard::{definition, VineyardCell, VineyardItem, VineyardRory};
+
+/// Typical [`ChicoStickMaterial`] / [`StandardMaterial`] Vineyard instance.
+pub type VineyardStd = Vineyard<
+	ChicoStickMaterial,
+	GroveSkippedStickMeshMaterial<ChicoStickMaterial>,
+	StandardMaterial,
+	SkippedLeafMeshMaterial<StandardMaterial>,
+	FlatTerrainSample,
+>;
+
+/// Vineyard grove preview (low trained-vine Rory forms).
+#[derive(Clone, Args)]
+#[command(rename_all = "kebab-case")]
+pub struct Vineyard<StickM, StickS, LeafM, LeafS, Terrain = FlatTerrainSample>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	#[command(flatten, next_help_heading = "Grove")]
+	pub grove: GroveFrontend,
+
+	#[command(flatten, next_help_heading = "Stick Material")]
+	pub stick_material: StickS,
+
+	#[command(flatten, next_help_heading = "Leaf Material")]
+	pub leaf_material: LeafS,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,1.0,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "The noise applied to the chains of sticks in trees",
+	)]
+	pub tree_chain_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.05,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Stick Surface Noise",
+	)]
+	pub stick_surface_noise: NoiseParams,
+
+	#[arg(
+		long,
+		default_value = "0,1.0,0.06,1",
+		value_parser = noise_params_from_scalar_str,
+		value_name = "SEED,FREQUENCY,AMPLITUDE,OCTAVES[,TYPE]",
+		help_heading = "Leaf Surface Noise",
+	)]
+	pub leaf_surface_noise: NoiseParams,
+
+	#[arg(skip)]
+	pub extent: GroveExtent,
+
+	#[command(flatten, next_help_heading = "Terrain")]
+	pub terrain: Terrain,
+
+	#[arg(skip)]
+	resolved_placements: Option<Vec<GrovePlacedCell<VineyardCell>>>,
+
+	#[arg(skip)]
+	__marker: PhantomData<fn() -> (StickM, LeafM)>,
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Default
+	for Vineyard<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn default() -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material: StickS::default(),
+			leaf_material: LeafS::default(),
+			tree_chain_noise: NoiseParams::from_scalar(0.0, 1.0, 1.0, 1),
+			stick_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.05, 1),
+			leaf_surface_noise: NoiseParams::from_scalar(0.0, 1.0, 0.06, 1),
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain: Terrain::default(),
+			resolved_placements: None,
+			__marker: PhantomData,
+		}
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> Vineyard<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static,
+	LeafM: Material,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	pub fn with_resolved_placements(
+		resolved_placements: Vec<GrovePlacedCell<VineyardCell>>,
+		terrain: Terrain,
+		tree_chain_noise: NoiseParams,
+		stick_surface_noise: NoiseParams,
+		leaf_surface_noise: NoiseParams,
+		stick_material: StickS,
+		leaf_material: LeafS,
+	) -> Self {
+		Self {
+			grove: GroveFrontend::default(),
+			stick_material,
+			leaf_material,
+			tree_chain_noise,
+			stick_surface_noise,
+			leaf_surface_noise,
+			extent: GroveExtent::new(
+				Vec3::ZERO,
+				Vec3::new(DEFAULT_GROVE_EXTENT_XZ, 1.0, DEFAULT_GROVE_EXTENT_XZ),
+			),
+			terrain,
+			resolved_placements: Some(resolved_placements),
+			__marker: PhantomData,
+		}
+	}
+
+	pub fn with_extent(mut self, extent: GroveExtent) -> Self {
+		self.extent = extent;
+		self
+	}
+
+	pub fn with_terrain(mut self, terrain: Terrain) -> Self {
+		self.terrain = terrain;
+		self
+	}
+
+	pub fn cell_extent_xz(&self) -> Vec2 {
+		self.grove.definition(definition()).cell_extent_xz
+	}
+
+	pub fn placement_cells(&self) -> Vec<gimme_gen::Cell> {
+		self.extent.subdivide_xz(self.cell_extent_xz())
+	}
+
+	pub fn placements(&self) -> Vec<GrovePlacedCell<VineyardCell>> {
+		if let Some(ref resolved) = self.resolved_placements {
+			return resolved.clone();
+		}
+		self.grove.assemble(definition()).populate(&self.extent, &self.terrain)
+	}
+}
+
+fn sample_f32(config: &NoiseConfig, range: UnitRange, salt: f32) -> f32 {
+	let lo = range.start.min(range.end);
+	let hi = range.start.max(range.end);
+	config.sample_range_f32_4d(lo, hi, 0.0, 0.0, 0.0, salt)
+}
+
+fn span_fraction(canopy_spread: f32, height: f32) -> f32 {
+	(canopy_spread / height.max(0.5)).clamp(0.25, 1.20)
+}
+
+impl BuildWithNoise<RorysHeadTrainedSbs> for VineyardRory {
+	fn build_with_noise(&self, noise: NoiseParams) -> RorysHeadTrainedSbs {
+		let config = NoiseConfig::new(noise);
+		let height =
+			sample_f32(&config, self.height, 1.0).max(self.height.start.min(self.height.end));
+		let stalk_radius = sample_f32(&config, self.stalk_radius, 1.5);
+		let canopy_spread = sample_f32(&config, self.canopy_spread, 2.0);
+
+		let mut geometry = RorysHeadTrainedSbs::default();
+		geometry.scale.tree_height = height;
+		geometry.scale.stalk_base_radius = Some(stalk_radius);
+		geometry.canopy_noise = noise;
+		let span = span_fraction(canopy_spread, height);
+		geometry.projection.span_fraction_of_height = UnitRange::new(span * 0.95, span * 1.15);
+		geometry
+	}
+}
+
+fn placement_transform<V>(placed: &GrovePlacedCell<V>) -> Transform {
+	Transform {
+		translation: placed.position,
+		rotation: Quat::IDENTITY,
+		scale: Vec3::splat(placed.scale.max(1e-4)),
+	}
+}
+
+impl<StickM, StickS, LeafM, LeafS, Terrain> RenderItem
+	for Vineyard<StickM, StickS, LeafM, LeafS, Terrain>
+where
+	StickM: Material + WithPalette + Default + Send + Sync + 'static,
+	StickS: Clone + Into<MeshMaterial3d<StickM>> + Args + Send + Sync + 'static + Default,
+	LeafM: Material + WithPalette + Default + Send + Sync + 'static,
+	LeafS: Clone + Into<MeshMaterial3d<LeafM>> + Args + Send + Sync + 'static + Default,
+	Terrain: TerrainSample + Clone + Send + Sync + 'static + Default + clap::Args,
+{
+	fn spawn_render_items(
+		&self,
+		commands: &mut Commands,
+		cascade_chunk: &CascadeChunk,
+		transform: Transform,
+	) -> Vec<Entity> {
+		let mut out = Vec::new();
+		for placed in self.placements() {
+			let local = transform.mul_transform(placement_transform(&placed));
+			let foliage_noise = placement_noise(self.leaf_surface_noise, placed.position);
+			let build_noise = placement_noise(self.grove.noise, placed.position);
+			let chain_noise = placement_noise(self.tree_chain_noise, placed.position);
+			let stick_seed = chain_noise.seed as i32;
+			let canopy_seed = build_noise.seed as i32 + 31;
+
+			let VineyardItem::Rory(vine) = placed.variant.item();
+			let geometry = vine.build_with_noise(build_noise);
+			let mut tree = RorysHeadTrained::<StickM, StickS, LeafM, LeafS>::default();
+			tree.geometry = geometry;
+			tree.stick_material = self.stick_material.clone();
+			tree.leaf_material = self.leaf_material.clone();
+			tree.stick_surface_noise = placement_noise(self.stick_surface_noise, placed.position);
+			tree.leaf_surface_noise = foliage_noise;
+			let entities = tree.spawn_render_items(commands, cascade_chunk, local);
+			patch_spawned_leaf_material::<StickM>(
+				&entities,
+				placed.variant.stick_palette_mix(),
+				stick_seed,
+				commands,
+			);
+			patch_spawned_leaf_material::<LeafM>(
+				&entities,
+				placed.variant.canopy_palette_mix(),
+				canopy_seed,
+				commands,
+			);
+			out.extend(entities);
+		}
+		out
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use anyhow::Result;
+
+	#[test]
+	fn vine_geometry_builds_within_authored_ranges() -> Result<()> {
+		let noise = placement_noise(NoiseParams::default(), Vec3::new(5.0, 0.0, 5.0));
+
+		let VineyardItem::Rory(vine) = VineyardCell::TrainedVineRory.item() else {
+			anyhow::bail!("expected trained vine rory item");
+		};
+		let geometry = vine.build_with_noise(noise);
+		assert!(geometry.scale.tree_height >= vine.height.start.min(vine.height.end));
+		assert!(geometry.scale.tree_height <= vine.height.start.max(vine.height.end));
+		Ok(())
+	}
+
+	#[test]
+	fn palette_resolves_for_all_varietals() -> Result<()> {
+		for cell in [VineyardCell::TrainedVineRory] {
+			for (palette, label) in
+				[(cell.stick_palette_mix(), "stick"), (cell.canopy_palette_mix(), "canopy")]
+			{
+				let mut allowed = Vec::new();
+				for slot in palette.slots {
+					allowed.extend(slot.start.resolve());
+					allowed.extend(slot.end.resolve());
+				}
+				assert!(!allowed.is_empty(), "unresolved {label} tokens for {cell:?}");
+			}
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn with_resolved_placements_skips_live_selection() -> Result<()> {
+		let placement =
+			GrovePlacedCell::new(VineyardCell::TrainedVineRory, Vec3::new(1.0, 0.0, 2.0), 1.0);
+		let item = VineyardStd::with_resolved_placements(
+			vec![placement.clone()],
+			FlatTerrainSample::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			NoiseParams::default(),
+			GroveSkippedStickMeshMaterial::<ChicoStickMaterial>::default(),
+			SkippedLeafMeshMaterial::<StandardMaterial>::default(),
+		);
+		assert_eq!(item.placements(), vec![placement]);
+		Ok(())
+	}
+}

--- a/maybraid/chico/groves/src/wandering_acacia.rs
+++ b/maybraid/chico/groves/src/wandering_acacia.rs
@@ -124,7 +124,7 @@ const DRY_WANDERING_SOPE: WanderingAcaciaBanyan = WanderingAcaciaBanyan {
 
 const WANDERING_VASE_TREE: WanderingAcaciaVaseTree = WanderingAcaciaVaseTree {
 	height: UnitRange::new(4.0, 8.0),
-	stalk_radius: UnitRange::new(0.16, 0.36),
+	stalk_radius: UnitRange::new(0.22, 0.48),
 	canopy_spread: UnitRange::new(0.5, 1.4),
 	canopy_density: SPARSE_CANOPY_DENSITY,
 };

--- a/maybraid/chico/sbs-trees-playground/src/commands/render.rs
+++ b/maybraid/chico/sbs-trees-playground/src/commands/render.rs
@@ -31,6 +31,8 @@ use crate::render::{
 	RenderJungleLowerMassives, RenderJungleMassives, RenderTemperateLowerMassives, RenderPalmShade,
 	RenderRiparianMix, RenderAlpine, RenderDryland, RenderStorytellers, RenderTradeWinds,
 	RenderWanderingAcacia, RenderLeeward, RenderChristmasTaiga,
+	RenderConiferMassives, RenderTemperateMassives, RenderRiparianGeneral, RenderRollingOaks,
+	RenderForlornSavanna, RenderOrchard, RenderVineyard, RenderDateGrove,
 	RenderVaseTree, RenderWaialeaPalm,
 	RenderWeepingTuft, RenderWildGrass,
 };
@@ -372,6 +374,70 @@ impl CellRenderHelper<RenderChristmasTaiga> {
 	}
 }
 
+impl CellRenderHelper<RenderConiferMassives> {
+	pub fn configured_conifer_massives(&self) -> RenderConiferMassives {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
+impl CellRenderHelper<RenderTemperateMassives> {
+	pub fn configured_temperate_massives(&self) -> RenderTemperateMassives {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
+impl CellRenderHelper<RenderRiparianGeneral> {
+	pub fn configured_riparian_general(&self) -> RenderRiparianGeneral {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
+impl CellRenderHelper<RenderRollingOaks> {
+	pub fn configured_rolling_oaks(&self) -> RenderRollingOaks {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
+impl CellRenderHelper<RenderForlornSavanna> {
+	pub fn configured_forlorn_savanna(&self) -> RenderForlornSavanna {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
+impl CellRenderHelper<RenderOrchard> {
+	pub fn configured_orchard(&self) -> RenderOrchard {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
+impl CellRenderHelper<RenderVineyard> {
+	pub fn configured_vineyard(&self) -> RenderVineyard {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
+impl CellRenderHelper<RenderDateGrove> {
+	pub fn configured_date_grove(&self) -> RenderDateGrove {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
 /// High bush shape plus the surface-noise flags that live on the render item (not the shape).
 #[derive(Clone, clap::Args)]
 #[command(rename_all = "kebab-case")]
@@ -469,6 +535,14 @@ pub enum Render {
 	WanderingAcacia(CellRenderHelper<RenderWanderingAcacia>),
 	Leeward(CellRenderHelper<RenderLeeward>),
 	ChristmasTaiga(CellRenderHelper<RenderChristmasTaiga>),
+	ConiferMassives(CellRenderHelper<RenderConiferMassives>),
+	TemperateMassives(CellRenderHelper<RenderTemperateMassives>),
+	RiparianGeneral(CellRenderHelper<RenderRiparianGeneral>),
+	RollingOaks(CellRenderHelper<RenderRollingOaks>),
+	ForlornSavanna(CellRenderHelper<RenderForlornSavanna>),
+	Orchard(CellRenderHelper<RenderOrchard>),
+	Vineyard(CellRenderHelper<RenderVineyard>),
+	DateGrove(CellRenderHelper<RenderDateGrove>),
 	SpearTuft(RenderHelper<SpearTuftShape>),
 	BuddhaHandTuft(RenderHelper<BuddhaHandTuftShape>),
 	WeepingTuft(RenderHelper<WeepingTuftShape>),
@@ -620,6 +694,26 @@ impl Render {
 			Self::Leeward(h) => h.render.config_with(RenderSubject::Leeward(h.configured_leeward())),
 			Self::ChristmasTaiga(h) => h.render.config_with(
 				RenderSubject::ChristmasTaiga(h.configured_christmas_taiga()),
+			),
+			Self::ConiferMassives(h) => h.render.config_with(
+				RenderSubject::ConiferMassives(h.configured_conifer_massives()),
+			),
+			Self::TemperateMassives(h) => h.render.config_with(
+				RenderSubject::TemperateMassives(h.configured_temperate_massives()),
+			),
+			Self::RiparianGeneral(h) => h.render.config_with(
+				RenderSubject::RiparianGeneral(h.configured_riparian_general()),
+			),
+			Self::RollingOaks(h) => h.render.config_with(
+				RenderSubject::RollingOaks(h.configured_rolling_oaks()),
+			),
+			Self::ForlornSavanna(h) => h.render.config_with(
+				RenderSubject::ForlornSavanna(h.configured_forlorn_savanna()),
+			),
+			Self::Orchard(h) => h.render.config_with(RenderSubject::Orchard(h.configured_orchard())),
+			Self::Vineyard(h) => h.render.config_with(RenderSubject::Vineyard(h.configured_vineyard())),
+			Self::DateGrove(h) => h.render.config_with(
+				RenderSubject::DateGrove(h.configured_date_grove()),
 			),
 			Self::SpearTuft(h) => h.config_with(RenderSubject::SpearTuft(
 				RenderSpearTuft::from_shape(h.inner.clone(), Default::default()),
@@ -2226,6 +2320,350 @@ mod tests {
 		let cfg = Render::ChristmasTaiga(helper).into_render_config();
 		let RenderSubject::ChristmasTaiga(subject) = cfg.subject else {
 			anyhow::bail!("expected christmas-taiga subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn conifer_massives_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render conifer-massives --grove-extent-xz 400",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::ConiferMassives(helper)) = cmd else {
+			anyhow::bail!("expected conifer-massives render command");
+		};
+		let grove = helper.configured_conifer_massives();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible conifer-massives preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn conifer_massives_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render conifer-massives --grove-extent-xz 400 --cell-extent-xz 50,50",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::ConiferMassives(helper)) = cmd else {
+			anyhow::bail!("expected conifer-massives render command");
+		};
+		assert!((helper.grove_extent_xz - 400.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(50.0)));
+		let grove = helper.configured_conifer_massives();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 64);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::ConiferMassives(helper).into_render_config();
+		let RenderSubject::ConiferMassives(subject) = cfg.subject else {
+			anyhow::bail!("expected conifer-massives subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn temperate_massives_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render temperate-massives --grove-extent-xz 400",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::TemperateMassives(helper)) = cmd
+		else {
+			anyhow::bail!("expected temperate-massives render command");
+		};
+		let grove = helper.configured_temperate_massives();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible temperate-massives preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn temperate_massives_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render temperate-massives --grove-extent-xz 400 --cell-extent-xz 49,49",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::TemperateMassives(helper)) = cmd
+		else {
+			anyhow::bail!("expected temperate-massives render command");
+		};
+		assert!((helper.grove_extent_xz - 400.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(49.0)));
+		let grove = helper.configured_temperate_massives();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 81);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::TemperateMassives(helper).into_render_config();
+		let RenderSubject::TemperateMassives(subject) = cfg.subject else {
+			anyhow::bail!("expected temperate-massives subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn riparian_general_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render riparian-general --grove-extent-xz 200",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::RiparianGeneral(helper)) = cmd else {
+			anyhow::bail!("expected riparian-general render command");
+		};
+		let grove = helper.configured_riparian_general();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible riparian-general preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn riparian_general_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render riparian-general --grove-extent-xz 200 --cell-extent-xz 16,16",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::RiparianGeneral(helper)) = cmd else {
+			anyhow::bail!("expected riparian-general render command");
+		};
+		assert!((helper.grove_extent_xz - 200.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(16.0)));
+		let grove = helper.configured_riparian_general();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 169);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::RiparianGeneral(helper).into_render_config();
+		let RenderSubject::RiparianGeneral(subject) = cfg.subject else {
+			anyhow::bail!("expected riparian-general subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn rolling_oaks_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render rolling-oaks --grove-extent-xz 260 --elevation 0.40",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::RollingOaks(helper)) = cmd else {
+			anyhow::bail!("expected rolling-oaks render command");
+		};
+		let grove = helper.configured_rolling_oaks();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible rolling-oaks preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn rolling_oaks_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render rolling-oaks --elevation 0.40 --grove-extent-xz 260 --cell-extent-xz 22,22",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::RollingOaks(helper)) = cmd else {
+			anyhow::bail!("expected rolling-oaks render command");
+		};
+		assert!((helper.grove_extent_xz - 260.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(22.0)));
+		let grove = helper.configured_rolling_oaks();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 144);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::RollingOaks(helper).into_render_config();
+		let RenderSubject::RollingOaks(subject) = cfg.subject else {
+			anyhow::bail!("expected rolling-oaks subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn forlorn_savanna_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render forlorn-savanna --grove-extent-xz 300",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::ForlornSavanna(helper)) = cmd else {
+			anyhow::bail!("expected forlorn-savanna render command");
+		};
+		let grove = helper.configured_forlorn_savanna();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible forlorn-savanna preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn forlorn_savanna_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render forlorn-savanna --grove-extent-xz 300 --cell-extent-xz 30,30",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::ForlornSavanna(helper)) = cmd else {
+			anyhow::bail!("expected forlorn-savanna render command");
+		};
+		assert!((helper.grove_extent_xz - 300.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(30.0)));
+		let grove = helper.configured_forlorn_savanna();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 100);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::ForlornSavanna(helper).into_render_config();
+		let RenderSubject::ForlornSavanna(subject) = cfg.subject else {
+			anyhow::bail!("expected forlorn-savanna subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn orchard_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line("render orchard --grove-extent-xz 160")
+			.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::Orchard(helper)) = cmd else {
+			anyhow::bail!("expected orchard render command");
+		};
+		let grove = helper.configured_orchard();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible orchard preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn orchard_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render orchard --grove-extent-xz 160 --cell-extent-xz 11,11",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::Orchard(helper)) = cmd else {
+			anyhow::bail!("expected orchard render command");
+		};
+		assert!((helper.grove_extent_xz - 160.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(11.0)));
+		let grove = helper.configured_orchard();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 225);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::Orchard(helper).into_render_config();
+		let RenderSubject::Orchard(subject) = cfg.subject else {
+			anyhow::bail!("expected orchard subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn vineyard_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render vineyard --grove-extent-xz 90 --elevation 0.35",
+		)
+			.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::Vineyard(helper)) = cmd else {
+			anyhow::bail!("expected vineyard render command");
+		};
+		let grove = helper.configured_vineyard();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible vineyard preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn vineyard_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render vineyard --elevation 0.35 --grove-extent-xz 90 --cell-extent-xz 4.5,4.5",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::Vineyard(helper)) = cmd else {
+			anyhow::bail!("expected vineyard render command");
+		};
+		assert!((helper.grove_extent_xz - 90.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(4.5)));
+		let grove = helper.configured_vineyard();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 400);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::Vineyard(helper).into_render_config();
+		let RenderSubject::Vineyard(subject) = cfg.subject else {
+			anyhow::bail!("expected vineyard subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn date_grove_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render date-grove --grove-extent-xz 160",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::DateGrove(helper)) = cmd else {
+			anyhow::bail!("expected date-grove render command");
+		};
+		let grove = helper.configured_date_grove();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible date-grove preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn date_grove_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render date-grove --grove-extent-xz 160 --cell-extent-xz 12,12",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::DateGrove(helper)) = cmd else {
+			anyhow::bail!("expected date-grove render command");
+		};
+		assert!((helper.grove_extent_xz - 160.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(12.0)));
+		let grove = helper.configured_date_grove();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 196);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::DateGrove(helper).into_render_config();
+		let RenderSubject::DateGrove(subject) = cfg.subject else {
+			anyhow::bail!("expected date-grove subject");
 		};
 		assert_eq!(subject.placement_cells().len(), cell_count);
 		assert!(!subject.placements().is_empty());

--- a/maybraid/chico/sbs-trees-playground/src/commands/render.rs
+++ b/maybraid/chico/sbs-trees-playground/src/commands/render.rs
@@ -30,7 +30,7 @@ use crate::render::{
 	RenderGoettingenFollow, RenderConiferSapling, RenderAridConiferSapling,
 	RenderJungleLowerMassives, RenderJungleMassives, RenderTemperateLowerMassives, RenderPalmShade,
 	RenderRiparianMix, RenderAlpine, RenderDryland, RenderStorytellers, RenderTradeWinds,
-	RenderWanderingAcacia, RenderLeeward,
+	RenderWanderingAcacia, RenderLeeward, RenderChristmasTaiga,
 	RenderVaseTree, RenderWaialeaPalm,
 	RenderWeepingTuft, RenderWildGrass,
 };
@@ -364,6 +364,14 @@ impl CellRenderHelper<RenderLeeward> {
 	}
 }
 
+impl CellRenderHelper<RenderChristmasTaiga> {
+	pub fn configured_christmas_taiga(&self) -> RenderChristmasTaiga {
+		let mut grove = self.render.inner.clone();
+		grove.extent = self.grove_extent(grove.cell_extent_xz());
+		grove
+	}
+}
+
 /// High bush shape plus the surface-noise flags that live on the render item (not the shape).
 #[derive(Clone, clap::Args)]
 #[command(rename_all = "kebab-case")]
@@ -460,6 +468,7 @@ pub enum Render {
 	TradeWinds(CellRenderHelper<RenderTradeWinds>),
 	WanderingAcacia(CellRenderHelper<RenderWanderingAcacia>),
 	Leeward(CellRenderHelper<RenderLeeward>),
+	ChristmasTaiga(CellRenderHelper<RenderChristmasTaiga>),
 	SpearTuft(RenderHelper<SpearTuftShape>),
 	BuddhaHandTuft(RenderHelper<BuddhaHandTuftShape>),
 	WeepingTuft(RenderHelper<WeepingTuftShape>),
@@ -609,6 +618,9 @@ impl Render {
 				RenderSubject::WanderingAcacia(h.configured_wandering_acacia()),
 			),
 			Self::Leeward(h) => h.render.config_with(RenderSubject::Leeward(h.configured_leeward())),
+			Self::ChristmasTaiga(h) => h.render.config_with(
+				RenderSubject::ChristmasTaiga(h.configured_christmas_taiga()),
+			),
 			Self::SpearTuft(h) => h.config_with(RenderSubject::SpearTuft(
 				RenderSpearTuft::from_shape(h.inner.clone(), Default::default()),
 			)),
@@ -2171,6 +2183,49 @@ mod tests {
 		let cfg = Render::Leeward(helper).into_render_config();
 		let RenderSubject::Leeward(subject) = cfg.subject else {
 			anyhow::bail!("expected leeward subject");
+		};
+		assert_eq!(subject.placement_cells().len(), cell_count);
+		assert!(!subject.placements().is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn christmas_taiga_defaults_spawn_placements() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render christmas-taiga --grove-extent-xz 200",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::ChristmasTaiga(helper)) = cmd else {
+			anyhow::bail!("expected christmas-taiga render command");
+		};
+		let grove = helper.configured_christmas_taiga();
+		let placements = grove.placements();
+		assert!(
+			!placements.is_empty(),
+			"expected a visible christmas-taiga preview with default flags, got {} placements",
+			placements.len()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn christmas_taiga_command_preserves_grove_params() -> Result<()> {
+		let cmd = crate::commands::PlaygroundCommand::parse_line(
+			"render christmas-taiga --grove-extent-xz 200 --cell-extent-xz 16,16",
+		)
+		.map_err(|e| anyhow::anyhow!("{e}"))?;
+		let crate::commands::PlaygroundCommand::Render(Render::ChristmasTaiga(helper)) = cmd else {
+			anyhow::bail!("expected christmas-taiga render command");
+		};
+		assert!((helper.grove_extent_xz - 200.0).abs() < 1e-5);
+		assert_eq!(helper.render.inner.grove.cell_extent_xz, Some(Vec2::splat(16.0)));
+		let grove = helper.configured_christmas_taiga();
+		let cell_count = grove.placement_cells().len();
+		assert_eq!(cell_count, 169);
+		assert!(!grove.placements().is_empty());
+		let cfg = Render::ChristmasTaiga(helper).into_render_config();
+		let RenderSubject::ChristmasTaiga(subject) = cfg.subject else {
+			anyhow::bail!("expected christmas-taiga subject");
 		};
 		assert_eq!(subject.placement_cells().len(), cell_count);
 		assert!(!subject.placements().is_empty());

--- a/maybraid/chico/sbs-trees-playground/src/render.rs
+++ b/maybraid/chico/sbs-trees-playground/src/render.rs
@@ -17,6 +17,7 @@ use chico_groves::alpine::AlpineStd;
 use chico_groves::dryland::DrylandStd;
 use chico_groves::storytellers::StorytellersStd;
 use chico_groves::trade_winds::TradeWindsStd;
+use chico_groves::christmas_taiga::ChristmasTaigaStd;
 use chico_groves::leeward::LeewardStd;
 use chico_groves::wandering_acacia::WanderingAcaciaStd;
 use chico_groves::palm_shade::PalmShadeStd;
@@ -329,6 +330,9 @@ pub type RenderWanderingAcacia = WanderingAcaciaStd;
 /// [`LeewardStd`] — moderate-density sheltered upper-canopy grove ([#339](https://github.com/ramate-io/maybraid/issues/339)).
 pub type RenderLeeward = LeewardStd;
 
+/// [`ChristmasTaigaStd`] — moderate-density cold Northern Conifer upper-canopy grove ([#341](https://github.com/ramate-io/maybraid/issues/341)).
+pub type RenderChristmasTaiga = ChristmasTaigaStd;
+
 /// The configured render item currently shown in the scene.
 ///
 /// This is the typed scene state behind [`RenderConfig`]: material patching
@@ -388,6 +392,7 @@ pub enum RenderSubject {
 	TradeWinds(RenderTradeWinds),
 	WanderingAcacia(RenderWanderingAcacia),
 	Leeward(RenderLeeward),
+	ChristmasTaiga(RenderChristmasTaiga),
 	SpearTuft(RenderSpearTuft),
 	BuddhaHandTuft(RenderBuddhaHandTuft),
 	WeepingTuft(RenderWeepingTuft),
@@ -451,6 +456,7 @@ impl RenderSubject {
 			Self::TradeWinds(_) => "TradeWinds",
 			Self::WanderingAcacia(_) => "WanderingAcacia",
 			Self::Leeward(_) => "Leeward",
+			Self::ChristmasTaiga(_) => "ChristmasTaiga",
 			Self::SpearTuft(_) => "SpearTuft",
 			Self::BuddhaHandTuft(_) => "BuddhaHandTuft",
 			Self::WeepingTuft(_) => "WeepingTuft",
@@ -818,6 +824,18 @@ impl RenderSubject {
 					g.leaf_surface_noise
 				)
 			}
+			Self::ChristmasTaiga(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
 			Self::StrangeOasis(g) => {
 				format!(
 					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
@@ -947,6 +965,7 @@ impl RenderSubject {
 			Self::TradeWinds(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::WanderingAcacia(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::Leeward(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::ChristmasTaiga(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::SpearTuft(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::BuddhaHandTuft(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::WeepingTuft(item) => item.spawn_render_items(commands, chunk, transform),

--- a/maybraid/chico/sbs-trees-playground/src/render.rs
+++ b/maybraid/chico/sbs-trees-playground/src/render.rs
@@ -18,7 +18,15 @@ use chico_groves::dryland::DrylandStd;
 use chico_groves::storytellers::StorytellersStd;
 use chico_groves::trade_winds::TradeWindsStd;
 use chico_groves::christmas_taiga::ChristmasTaigaStd;
+use chico_groves::conifer_massives::ConiferMassivesStd;
+use chico_groves::date_grove::DateGroveStd;
+use chico_groves::forlorn_savanna::ForlornSavannaStd;
 use chico_groves::leeward::LeewardStd;
+use chico_groves::orchard::OrchardStd;
+use chico_groves::riparian_general::RiparianGeneralStd;
+use chico_groves::rolling_oaks::RollingOaksStd;
+use chico_groves::temperate_massives::TemperateMassivesStd;
+use chico_groves::vineyard::VineyardStd;
 use chico_groves::wandering_acacia::WanderingAcaciaStd;
 use chico_groves::palm_shade::PalmShadeStd;
 use chico_groves::riparian_mix::RiparianMixStd;
@@ -333,6 +341,30 @@ pub type RenderLeeward = LeewardStd;
 /// [`ChristmasTaigaStd`] — moderate-density cold Northern Conifer upper-canopy grove ([#341](https://github.com/ramate-io/maybraid/issues/341)).
 pub type RenderChristmasTaiga = ChristmasTaigaStd;
 
+/// [`ConiferMassivesStd`] — moderate giant conifer upper-canopy grove.
+pub type RenderConiferMassives = ConiferMassivesStd;
+
+/// [`TemperateMassivesStd`] — moderate giant temperate upper-canopy grove.
+pub type RenderTemperateMassives = TemperateMassivesStd;
+
+/// [`RiparianGeneralStd`] — mixed riparian upper-canopy grove.
+pub type RenderRiparianGeneral = RiparianGeneralStd;
+
+/// [`RollingOaksStd`] — rolling oak upper-canopy grove.
+pub type RenderRollingOaks = RollingOaksStd;
+
+/// [`ForlornSavannaStd`] — sparse dry savanna upper-canopy grove.
+pub type RenderForlornSavanna = ForlornSavannaStd;
+
+/// [`OrchardStd`] — cultivated orchard upper-canopy grove.
+pub type RenderOrchard = OrchardStd;
+
+/// [`VineyardStd`] — cultivated vineyard upper-canopy grove.
+pub type RenderVineyard = VineyardStd;
+
+/// [`DateGroveStd`] — date palm upper-canopy grove.
+pub type RenderDateGrove = DateGroveStd;
+
 /// The configured render item currently shown in the scene.
 ///
 /// This is the typed scene state behind [`RenderConfig`]: material patching
@@ -393,6 +425,14 @@ pub enum RenderSubject {
 	WanderingAcacia(RenderWanderingAcacia),
 	Leeward(RenderLeeward),
 	ChristmasTaiga(RenderChristmasTaiga),
+	ConiferMassives(RenderConiferMassives),
+	TemperateMassives(RenderTemperateMassives),
+	RiparianGeneral(RenderRiparianGeneral),
+	RollingOaks(RenderRollingOaks),
+	ForlornSavanna(RenderForlornSavanna),
+	Orchard(RenderOrchard),
+	Vineyard(RenderVineyard),
+	DateGrove(RenderDateGrove),
 	SpearTuft(RenderSpearTuft),
 	BuddhaHandTuft(RenderBuddhaHandTuft),
 	WeepingTuft(RenderWeepingTuft),
@@ -457,6 +497,14 @@ impl RenderSubject {
 			Self::WanderingAcacia(_) => "WanderingAcacia",
 			Self::Leeward(_) => "Leeward",
 			Self::ChristmasTaiga(_) => "ChristmasTaiga",
+			Self::ConiferMassives(_) => "ConiferMassives",
+			Self::TemperateMassives(_) => "TemperateMassives",
+			Self::RiparianGeneral(_) => "RiparianGeneral",
+			Self::RollingOaks(_) => "RollingOaks",
+			Self::ForlornSavanna(_) => "ForlornSavanna",
+			Self::Orchard(_) => "Orchard",
+			Self::Vineyard(_) => "Vineyard",
+			Self::DateGrove(_) => "DateGrove",
 			Self::SpearTuft(_) => "SpearTuft",
 			Self::BuddhaHandTuft(_) => "BuddhaHandTuft",
 			Self::WeepingTuft(_) => "WeepingTuft",
@@ -836,6 +884,102 @@ impl RenderSubject {
 					g.leaf_surface_noise
 				)
 			}
+			Self::ConiferMassives(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
+			Self::TemperateMassives(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
+			Self::RiparianGeneral(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
+			Self::RollingOaks(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
+			Self::ForlornSavanna(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
+			Self::Orchard(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
+			Self::Vineyard(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
+			Self::DateGrove(g) => {
+				format!(
+					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
+					g.grove,
+					g.extent,
+					g.cell_extent_xz(),
+					g.terrain,
+					g.tree_chain_noise,
+					g.stick_surface_noise,
+					g.leaf_surface_noise
+				)
+			}
 			Self::StrangeOasis(g) => {
 				format!(
 					"{:?}|extent={:?}|cell_extent_xz={:?}|terrain={:?}|chain={:?}|stick={:?}|leaf={:?}",
@@ -966,6 +1110,14 @@ impl RenderSubject {
 			Self::WanderingAcacia(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::Leeward(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::ChristmasTaiga(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::ConiferMassives(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::TemperateMassives(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::RiparianGeneral(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::RollingOaks(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::ForlornSavanna(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::Orchard(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::Vineyard(item) => item.spawn_render_items(commands, chunk, transform),
+			Self::DateGrove(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::SpearTuft(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::BuddhaHandTuft(item) => item.spawn_render_items(commands, chunk, transform),
 			Self::WeepingTuft(item) => item.spawn_render_items(commands, chunk, transform),

--- a/maybraid/chico/sbs-trees-playground/src/render_materials.rs
+++ b/maybraid/chico/sbs-trees-playground/src/render_materials.rs
@@ -368,6 +368,38 @@ fn attach_render_materials(
 			g.stick_material.mesh = MeshMaterial3d(stick.clone());
 			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
 		}
+		RenderSubject::ConiferMassives(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
+		RenderSubject::TemperateMassives(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
+		RenderSubject::RiparianGeneral(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
+		RenderSubject::RollingOaks(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
+		RenderSubject::ForlornSavanna(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
+		RenderSubject::Orchard(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
+		RenderSubject::Vineyard(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
+		RenderSubject::DateGrove(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
 		RenderSubject::StrangeOasis(g) => {
 			g.stick_material.mesh = MeshMaterial3d(stick.clone());
 			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());

--- a/maybraid/chico/sbs-trees-playground/src/render_materials.rs
+++ b/maybraid/chico/sbs-trees-playground/src/render_materials.rs
@@ -364,6 +364,10 @@ fn attach_render_materials(
 			g.stick_material.mesh = MeshMaterial3d(stick.clone());
 			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
 		}
+		RenderSubject::ChristmasTaiga(g) => {
+			g.stick_material.mesh = MeshMaterial3d(stick.clone());
+			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());
+		}
 		RenderSubject::StrangeOasis(g) => {
 			g.stick_material.mesh = MeshMaterial3d(stick.clone());
 			g.leaf_material.mesh = MeshMaterial3d(tuft.clone());

--- a/pr-bodies/341-christmas-taiga.md
+++ b/pr-bodies/341-christmas-taiga.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Christmas Taiga upper-canopy grove: dense cold Northern Conifer forms with a colder high-band variant.
+
+Resolves #341
+
+```
+render christmas-taiga --grove-extent-xz 200
+```

--- a/pr-bodies/343-conifer-massives.md
+++ b/pr-bodies/343-conifer-massives.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Conifer Massives upper-canopy grove per RFC-183 §3.4.7.
+
+Resolves #343
+
+```
+render conifer-massives --grove-extent-xz 400
+```

--- a/pr-bodies/345-temperate-massives.md
+++ b/pr-bodies/345-temperate-massives.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Temperate Massives upper-canopy grove per RFC-183 §3.4.7.
+
+Resolves #345
+
+```
+render temperate-massives --grove-extent-xz 400
+```

--- a/pr-bodies/347-riparian-general.md
+++ b/pr-bodies/347-riparian-general.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Riparian General upper-canopy grove per RFC-183 §3.4.7.
+
+Resolves #347
+
+```
+render riparian-general --grove-extent-xz 200
+```

--- a/pr-bodies/349-rolling-oaks.md
+++ b/pr-bodies/349-rolling-oaks.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Rolling Oaks upper-canopy grove per RFC-183 §3.4.7.
+
+Resolves #349
+
+```
+render rolling-oaks --grove-extent-xz 260
+```

--- a/pr-bodies/351-forlorn-savanna.md
+++ b/pr-bodies/351-forlorn-savanna.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Forlorn Savanna upper-canopy grove per RFC-183 §3.4.7.
+
+Resolves #351
+
+```
+render forlorn-savanna --grove-extent-xz 300
+```

--- a/pr-bodies/353-orchard.md
+++ b/pr-bodies/353-orchard.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Orchard upper-canopy grove per RFC-183 §3.4.7.
+
+Resolves #353
+
+```
+render orchard --grove-extent-xz 160
+```

--- a/pr-bodies/355-vineyard.md
+++ b/pr-bodies/355-vineyard.md
@@ -1,0 +1,9 @@
+# Summary
+
+Implements Vineyard upper-canopy grove per RFC-183 §3.4.7.
+
+Resolves #355
+
+```
+render vineyard --grove-extent-xz 90
+```

--- a/pr-bodies/357-date-grove.md
+++ b/pr-bodies/357-date-grove.md
@@ -1,0 +1,11 @@
+# Summary
+
+Implements Date Grove upper-canopy grove per RFC-183 §3.4.7.
+
+Includes playground CLI wiring for all #343–#357 groves.
+
+Resolves #357
+
+```
+render date-grove --grove-extent-xz 160
+```


### PR DESCRIPTION
# Summary

Implements Date Grove upper-canopy grove per RFC-183 §3.4.7.

Includes playground CLI wiring for all #343–#357 groves.

Resolves #357

```
render date-grove --grove-extent-xz 160
```
