### PR TITLE
Adds group species picker by body plan in character menus.

### DIFF
--- a/maybraid/crozon/bevy-character-ui-menu-renderer/src/sink.rs
+++ b/maybraid/crozon/bevy-character-ui-menu-renderer/src/sink.rs
@@ -70,19 +70,26 @@ impl<E: Copy + Send + Sync + 'static> MenuSink<E> for BevyMenuSink {
 		match node {
 			MenuNode::Fragment(children) => self.render_nodes(children, parent, context),
 			MenuNode::Section { label, children } => self.section(label, children, parent, context),
-			MenuNode::SectionSelect { label, choices, children } => {
+			MenuNode::SectionSelect { label, groups, children } => {
 				block_label(parent, label);
-				parent.spawn((inline_chip_row(), Pickable::IGNORE)).with_children(|row| {
-					for choice in choices {
-						row.spawn((
-							Button,
-							select_tile_node(),
-							BackgroundColor(if choice.selected { ACTIVE } else { INACTIVE }),
-							crate::widgets::MenuButton(choice.event),
-						))
-						.with_children(|button| tile_text(button, choice.label, 9.0, Color::WHITE));
+				for group in groups {
+					if let Some(group_label) = group.label {
+						text(parent, group_label, 10.0, MUTED);
 					}
-				});
+					parent.spawn((inline_chip_row(), Pickable::IGNORE)).with_children(|row| {
+						for choice in &group.choices {
+							row.spawn((
+								Button,
+								select_tile_node(),
+								BackgroundColor(if choice.selected { ACTIVE } else { INACTIVE }),
+								crate::widgets::MenuButton(choice.event),
+							))
+							.with_children(|button| {
+								tile_text(button, choice.label, 9.0, Color::WHITE)
+							});
+						}
+					});
+				}
 				self.render_nodes(children, parent, context);
 			}
 			MenuNode::LabeledCycle { label, value, minus, plus } => {

--- a/maybraid/crozon/character-ui-menu/src/lib.rs
+++ b/maybraid/crozon/character-ui-menu/src/lib.rs
@@ -15,7 +15,7 @@ pub mod traits;
 pub use camera_focus::{CameraFocus, FocusRig};
 pub use node::{
 	normalize, AssetChoice, ItemRow, MenuComponent, MenuNode, PreviewColor, SelectChoice,
-	SwatchChoice,
+	SelectGroup, SwatchChoice,
 };
 pub use primitives::{
 	AssetSingleSelect, IdentifiedAsset, MultiSelect, Section, SingleSelect, Slider,

--- a/maybraid/crozon/character-ui-menu/src/node.rs
+++ b/maybraid/crozon/character-ui-menu/src/node.rs
@@ -59,6 +59,46 @@ pub struct SelectChoice<E> {
 	pub event: E,
 }
 
+/// Labeled subgroup of select tiles inside a [`MenuNode::SectionSelect`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct SelectGroup<E> {
+	/// Subheading above the choice row; omit for a single unlabeled row.
+	pub label: Option<&'static str>,
+	pub choices: Vec<SelectChoice<E>>,
+}
+
+impl<E> SelectGroup<E> {
+	pub fn unlabeled(choices: Vec<SelectChoice<E>>) -> Self {
+		Self { label: None, choices }
+	}
+
+	pub fn labeled(label: &'static str, choices: Vec<SelectChoice<E>>) -> Self {
+		Self { label: Some(label), choices }
+	}
+
+	pub fn from_values<T>(
+		group_label: Option<&'static str>,
+		selected: T,
+		mut event: impl FnMut(T) -> E,
+		values: &[T],
+	) -> Self
+	where
+		T: LabelOption + PartialEq + Copy,
+	{
+		Self {
+			label: group_label,
+			choices: values
+				.iter()
+				.map(|value| SelectChoice {
+					label: value.label(),
+					selected: *value == selected,
+					event: event(*value),
+				})
+				.collect(),
+		}
+	}
+}
+
 /// One color swatch in a swatch row.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SwatchChoice<E> {
@@ -131,8 +171,13 @@ pub enum MenuNode<E> {
 	/// [`crate::SectionOpen`].
 	Section { label: &'static str, children: Vec<MenuNode<E>> },
 	/// Tile picker whose selection decides the subtree below it
-	/// (e.g. the species picker). Only the selected subtree is lowered.
-	SectionSelect { label: &'static str, choices: Vec<SelectChoice<E>>, children: Vec<MenuNode<E>> },
+	/// (e.g. the species picker). Choices may be split into labeled groups for
+	/// readability; only the selected subtree is lowered into `children`.
+	SectionSelect {
+		label: &'static str,
+		groups: Vec<SelectGroup<E>>,
+		children: Vec<MenuNode<E>>,
+	},
 	/// `<` value `>` control with an inline label.
 	LabeledCycle { label: &'static str, value: &'static str, minus: E, plus: E },
 	/// `-` value `+` stepped scalar control with an inline label.
@@ -173,12 +218,28 @@ impl<E> MenuNode<E> {
 	{
 		Self::SectionSelect {
 			label,
-			choices: T::values()
+			groups: vec![SelectGroup::from_values(None, selected, &mut event, T::values())],
+			children: normalize(vec![child]),
+		}
+	}
+
+	/// Like [`Self::section_select`], but splits choices into labeled groups.
+	pub fn section_select_grouped<T>(
+		label: &'static str,
+		selected: T,
+		mut event: impl FnMut(T) -> E,
+		groups: &[(&'static str, &[T])],
+		child: MenuNode<E>,
+	) -> Self
+	where
+		T: LabelOption + PartialEq + Copy,
+	{
+		Self::SectionSelect {
+			label,
+			groups: groups
 				.iter()
-				.map(|value| SelectChoice {
-					label: value.label(),
-					selected: *value == selected,
-					event: event(*value),
+				.map(|(group_label, values)| {
+					SelectGroup::from_values(Some(*group_label), selected, &mut event, values)
 				})
 				.collect(),
 			children: normalize(vec![child]),

--- a/maybraid/crozon/character-ui-menus/src/character.rs
+++ b/maybraid/crozon/character-ui-menus/src/character.rs
@@ -119,7 +119,16 @@ impl ConceptSpecies {
 impl ListValues for ConceptSpecies {
 	fn values() -> &'static [Self] {
 		&[
+			// Humanoids
 			Self::Braidman,
+			Self::Brodler,
+			Self::Mygr,
+			Self::Dui,
+			Self::Wumbus,
+			Self::Lero,
+			Self::Spibmom,
+			Self::Tuberwaber,
+			// Quadrupeds
 			Self::Brenal,
 			Self::Caole,
 			Self::Epiphant,
@@ -128,9 +137,7 @@ impl ListValues for ConceptSpecies {
 			Self::Sonyak,
 			Self::Claber,
 			Self::Croconot,
-			Self::Brodler,
-			Self::Mygr,
-			Self::Dui,
+			// Birds
 			Self::Lidder,
 			Self::Chupri,
 			Self::Brokker,
@@ -140,13 +147,10 @@ impl ListValues for ConceptSpecies {
 			Self::Tapp,
 			Self::Kaller,
 			Self::Kappler,
-			Self::Wumbus,
-			Self::Lero,
-			Self::Spibmom,
+			// Aquatic
 			Self::Grener,
 			Self::Thumplus,
 			Self::Mistler,
-			Self::Tuberwaber,
 		]
 	}
 }
@@ -3104,10 +3108,60 @@ impl CharacterMenu {
 
 impl MenuComponent<MenuEvent> for CharacterMenu {
 	fn menu_node(&self) -> MenuNode<MenuEvent> {
-		MenuNode::section_select(
+		MenuNode::section_select_grouped(
 			"Species",
 			self.species.value,
 			MenuEvent::SetSpecies,
+			&[
+				(
+					"Humanoids",
+					&[
+						ConceptSpecies::Braidman,
+						ConceptSpecies::Brodler,
+						ConceptSpecies::Mygr,
+						ConceptSpecies::Dui,
+						ConceptSpecies::Wumbus,
+						ConceptSpecies::Lero,
+						ConceptSpecies::Spibmom,
+						ConceptSpecies::Tuberwaber,
+					],
+				),
+				(
+					"Quadrupeds",
+					&[
+						ConceptSpecies::Brenal,
+						ConceptSpecies::Caole,
+						ConceptSpecies::Epiphant,
+						ConceptSpecies::Hars,
+						ConceptSpecies::Yilter,
+						ConceptSpecies::Sonyak,
+						ConceptSpecies::Claber,
+						ConceptSpecies::Croconot,
+					],
+				),
+				(
+					"Birds",
+					&[
+						ConceptSpecies::Lidder,
+						ConceptSpecies::Chupri,
+						ConceptSpecies::Brokker,
+						ConceptSpecies::Tipple,
+						ConceptSpecies::Topple,
+						ConceptSpecies::Kispar,
+						ConceptSpecies::Tapp,
+						ConceptSpecies::Kaller,
+						ConceptSpecies::Kappler,
+					],
+				),
+				(
+					"Aquatic",
+					&[
+						ConceptSpecies::Grener,
+						ConceptSpecies::Thumplus,
+						ConceptSpecies::Mistler,
+					],
+				),
+			],
 			self.species_node(),
 		)
 	}

--- a/maybraid/crozon/character-ui-menus/src/tests.rs
+++ b/maybraid/crozon/character-ui-menus/src/tests.rs
@@ -356,12 +356,19 @@ fn character_menu_lowers_to_species_select_tree() -> anyhow::Result<()> {
 	let menu = CharacterMenu::default();
 	let nodes = menu.menu_nodes();
 	assert_eq!(nodes.len(), 1);
-	let MenuNode::SectionSelect { label, choices, children } = &nodes[0] else {
+	let MenuNode::SectionSelect { label, groups, children } = &nodes[0] else {
 		anyhow::bail!("expected a species SectionSelect at the root");
 	};
 	assert_eq!(*label, "Species");
-	assert_eq!(choices.len(), 28);
-	assert!(choices[0].selected, "default species should be braidman");
+	assert_eq!(groups.len(), 4);
+	assert_eq!(groups[0].label, Some("Humanoids"));
+	assert_eq!(groups[1].label, Some("Quadrupeds"));
+	assert_eq!(groups[2].label, Some("Birds"));
+	assert_eq!(groups[3].label, Some("Aquatic"));
+	let choice_count: usize = groups.iter().map(|group| group.choices.len()).sum();
+	assert_eq!(choice_count, 28);
+	assert!(groups[0].choices[0].selected, "default species should be braidman");
+	assert_eq!(groups[0].choices[0].label, "braidman");
 	// Braidman: presets, body, head & features, hair, clothing, animation.
 	assert_eq!(children.len(), 6);
 	assert!(children.iter().all(|child| matches!(child, MenuNode::Section { .. })));


### PR DESCRIPTION
The concepts screen species row was a flat list of 28 tiles. Extend `SectionSelect` with labeled `SelectGroup`s and render muted subheadings above each chip row so Humanoids, Quadrupeds, Birds, and Aquatic read as clear clusters without changing selection behavior.