### PR TITLE
Fixes mesh fit by making lake fill on the shared terrain cascade lattice

### DIFF
--- a/maybraid/durham/marazion/src/fill.rs
+++ b/maybraid/durham/marazion/src/fill.rs
@@ -1,20 +1,23 @@
-//! Stamp-owned water fill for Marazion pocket bodies.
+//! Stamp-owned water fill for Marazion pocket bodies (lakes first).
 //!
-//! Softmask sets the **horizontal** wet footprint. The volume itself is a
-//! bleed-tolerant difference against terrain:
+//! Softmask sets the **horizontal** wet footprint. A column is wet only when
+//! \(W > h - u\) (undercut lets shoreline bleed under raised rims). Inside a wet
+//! column the solid is a **half-space below the free surface**:
 //!
 //! \[
-//! d = \max(y - W,\; (h - u) - y)
+//! d = y - W
 //! \]
 //!
-//! where \(u\) is [`WaterFill::terrain_undercut`]. Exact difference (`u = 0`)
-//! has **no volume** wherever the rim sits above \(W\); undercut pushes water
-//! into the bank so shoreline bleed is real, not only a wider softmask.
+//! (plus softmask fade). That matches terrain-style meshing on the shared
+//! origin-cell cascade lattice: marching cubes resolves the free surface on the
+//! same tall Y grid as terrain; subterranean volume is intentional and fine.
+//! Islands / beds above \(W\) stay dry because the undercut gate fails.
 
 use bevy_math::{Vec2, Vec3};
 use jersey_terrain_stamps::{Region2D, RegionNoise};
 
-/// Large positive distance used when a sample is outside the softmask boundary.
+/// Large positive distance used when a sample is outside the softmask boundary
+/// or the column is dry (\(W \le h_{\mathrm{eff}}\)).
 const OUTSIDE_FILL_DISTANCE: f32 = 1.0e6;
 
 /// Stamp-owned water volume (Lake first).
@@ -32,9 +35,10 @@ pub struct WaterFill {
 	pub noise: Option<RegionNoise>,
 	/// Water surface elevation decided by the stamp.
 	pub water_level: f32,
-	/// Push water into terrain by this many world units (`h_eff = h - undercut`).
+	/// Push the wet-column gate into terrain (`h_eff = h - undercut`).
 	///
 	/// Must be ≥ rim lift (plus a little) or the raised bank still blocks fill.
+	/// Does **not** set slab thickness — wet columns are half-spaces below \(W\).
 	pub terrain_undercut: f32,
 }
 
@@ -49,33 +53,43 @@ impl WaterFill {
 		)
 	}
 
-	/// Effective terrain height for the bleed-tolerant difference.
+	/// Effective terrain height for the wet-column gate.
 	pub fn effective_terrain_height(&self, terrain_height: f32) -> f32 {
 		terrain_height - self.terrain_undercut.max(0.0)
 	}
 
-	/// Vertical wet interval `[h_eff, W]` when the column has volume under softmask.
+	/// Whether this column is wet under softmask + undercut (`W > h_eff`).
+	pub fn column_is_wet(&self, terrain_height: f32) -> bool {
+		self.water_level > self.effective_terrain_height(terrain_height)
+	}
+
+	/// Vertical wet interval when the column is wet: \((-\infty, W]\).
+	///
+	/// Open downward so Durham water can share the terrain cell's full Y lattice.
 	pub fn wet_y_span(&self, terrain_height: f32) -> Option<(f32, f32)> {
-		let h_eff = self.effective_terrain_height(terrain_height);
-		if self.water_level > h_eff {
-			Some((h_eff, self.water_level))
+		if self.column_is_wet(terrain_height) {
+			Some((f32::NEG_INFINITY, self.water_level))
 		} else {
 			None
 		}
 	}
 
-	/// Softmask-clipped, bleed-tolerant water fill.
+	/// Softmask-clipped free-surface half-space (wet below \(W\)).
 	///
 	/// \[
-	/// d = \max(y - W,\; (h - u) - y)
+	/// d = y - W
 	/// \]
+	///
+	/// outside softmask or when \(W \le h_{\mathrm{eff}}\) → dry.
 	pub fn distance(&self, p: Vec3, terrain_height: f32) -> f32 {
 		let w = self.softmask_at(p.x, p.z);
 		if w >= 1.0 {
 			return OUTSIDE_FILL_DISTANCE;
 		}
-		let h_eff = self.effective_terrain_height(terrain_height);
-		let fill = (p.y - self.water_level).max(h_eff - p.y);
+		if !self.column_is_wet(terrain_height) {
+			return OUTSIDE_FILL_DISTANCE;
+		}
+		let fill = p.y - self.water_level;
 		fill + w * OUTSIDE_FILL_DISTANCE
 	}
 }
@@ -100,7 +114,7 @@ mod tests {
 			water_level: w,
 			terrain_undercut: 0.0,
 		};
-		// Exact difference: no volume when rim is above W.
+		// Exact gate: no volume when rim is above W.
 		assert!(fill.wet_y_span(rim_h).is_none());
 		let mid = Vec3::new(0.0, w - 0.5, 0.0);
 		assert!(fill.distance(mid, rim_h) > 0.0);
@@ -110,8 +124,30 @@ mod tests {
 			..fill
 		};
 		let span = bled.wet_y_span(rim_h).expect("undercut volume");
-		assert!(span.0 < w && span.1 == w);
+		assert!(span.0.is_infinite() && span.0.is_sign_negative());
+		assert_eq!(span.1, w);
 		assert!(bled.distance(mid, rim_h) < 0.0);
+		Ok(())
+	}
+
+	#[test]
+	fn wet_column_is_half_space_below_surface() -> anyhow::Result<()> {
+		let w = 50.0;
+		let fill = WaterFill {
+			region: Region2D::Circle(CircleRegion {
+				center: Vec2::ZERO,
+				radius: 40.0,
+			}),
+			inner_radius: 0.0,
+			outer_radius: 1.0,
+			noise: None,
+			water_level: w,
+			terrain_undercut: 2.0,
+		};
+		let bed = w - 5.0;
+		assert!(fill.column_is_wet(bed));
+		assert!(fill.distance(Vec3::new(0.0, w - 1000.0, 0.0), bed) < 0.0);
+		assert!(fill.distance(Vec3::new(0.0, w + 1.0, 0.0), bed) > 0.0);
 		Ok(())
 	}
 }

--- a/maybraid/durham/marazion/src/lake.rs
+++ b/maybraid/durham/marazion/src/lake.rs
@@ -89,7 +89,9 @@ pub struct LakeParams {
 	pub water_sink: f32,
 	/// How far the rim shelf sits **above** the shelf anchor (world units).
 	pub rim_lift: f32,
-	/// How far the water difference bites into terrain (`h − undercut`).
+	/// How far the wet-column gate bites into terrain (`h − undercut`).
+	/// Wet columns are half-spaces below \(W\); undercut only decides which
+	/// columns count as wet (shoreline under raised rims).
 	pub terrain_undercut: f32,
 	/// Per-leaf jitter on the shelf anchor height that sets `W` and rim base.
 	pub shelf_amp: f32,

--- a/maybraid/durham/models-playground/src/lib.rs
+++ b/maybraid/durham/models-playground/src/lib.rs
@@ -154,7 +154,6 @@ pub(crate) fn setup_presentation_assets(
 	});
 	commands.insert_resource(WaterPresentationAssets {
 		material: water_material,
-		res_2: 5,
 	});
 }
 

--- a/maybraid/durham/models/CONTRIBUTING.md
+++ b/maybraid/durham/models/CONTRIBUTING.md
@@ -115,3 +115,31 @@ identity outside its bounded support. No apron or overlap region is required.
    sample domain.
 4. Chunks never evaluate terrain beyond their owned sample domain.
 5. Modulation composition order is globally deterministic.
+
+## Water fill composition (same lattice as terrain)
+
+Water is a **second composition pass** on the same origin cells as terrain — not a
+separate spatial tiling and not a fitted vertical AABB.
+
+| Concern | Owner |
+| --- | --- |
+| Origin-cell tiling / cell size | [`TerrainCellLayout`](src/terrain/cell.rs) via `original_ids_for_origin_cells` (shared by `Terrain` and `Water`) |
+| Heightfield composition | [`ComposedTerrain`](src/terrain/sdf.rs) / `Terrain::compose_sdf` |
+| Wet-volume composition | [`ComposedWater`](src/water/composed.rs) / `ComposedWater::compose` |
+| Cascade chunk (`origin`, extent, Y, `res_2`) | [`cascade_chunk_for_cell`](src/terrain/render.rs) for **both** `Terrain::scene` and `Water::scene` |
+| Mesh resolution | `TerrainPresentationAssets.res_2` on the terrain cell; `Water` copies `terrain.res_2` |
+
+Marazion lake stamps author [`WaterFill`](../marazion/src/fill.rs): softmask + undercut
+gate columns, then a **half-space below \(W\)** (not a thin \([h, W]\) slab). That is
+what lets water share terrain's tall cell Y without vanishing under marching cubes.
+Subterranean wet volume is intentional.
+
+### Rules
+
+1. **Do not** introduce a water-only cell layout or a water-only `res_2`.
+2. **Do not** fit a water-only Y span for meshing. Prefer free-surface half-spaces
+   (or otherwise thick wet solids) on the shared lattice.
+3. Softmask bleed / overspill stays on the fill region; empty cells may skip the
+   water pass entirely.
+4. Optional later: split chunks per feature (e.g. water material/color) while
+   keeping the same cascade lattice.

--- a/maybraid/durham/models/src/terrain.rs
+++ b/maybraid/durham/models/src/terrain.rs
@@ -140,6 +140,7 @@ impl Terrain {
 	}
 
 	pub fn scene(&self) -> impl Scene + 'static {
+		// Shared origin-cell lattice with [`crate::water::Water::scene`].
 		let chunk = cascade_chunk_for_cell(self.cell, self.res_2);
 		let transform = Transform::from_translation(chunk.origin);
 		let sdf = self.sdf.clone();

--- a/maybraid/durham/models/src/terrain/render.rs
+++ b/maybraid/durham/models/src/terrain/render.rs
@@ -84,34 +84,6 @@ pub fn cascade_chunk_for_cell(bounds: Aabb3d, res_2: u8) -> CascadeChunk {
 	cascade_chunk_from_aabb(padded, res_2)
 }
 
-/// Cascade chunk for water meshing: **same XZ grid as terrain**, fitted Y span.
-///
-/// Terrain cells use a huge vertical half-extent (~±2000). Reusing that AABB for
-/// water makes `cube_cell.y` hundreds of meters — thicker than a lake — so the
-/// slab never fills the carved basin. Keep XZ origin/extent/`res_2` matched to
-/// [`cascade_chunk_for_cell`] so shore samples align with the terrain mesh.
-pub fn cascade_chunk_for_water_cell(
-	bounds: Aabb3d,
-	res_2: u8,
-	y_min: f32,
-	y_max: f32,
-) -> CascadeChunk {
-	let min0 = Vec3::from(bounds.min);
-	let max0 = Vec3::from(bounds.max);
-	let base = max0 - min0;
-	let res = 2_f32.powi(res_2 as i32).max(1.0);
-	let xz_pitch = base.x.min(base.z) / res;
-	let pad_xz = xz_pitch * TERRAIN_MESH_PAD_VOXELS;
-	let padded_xz = expand_aabb_xz_y(bounds, pad_xz, 0.0);
-	let y0 = y_min.min(y_max);
-	let y1 = y_min.max(y_max).max(y0 + 1.0);
-	let water_bounds = Aabb3d::from_min_max(
-		Vec3::new(padded_xz.min.x, y0, padded_xz.min.z),
-		Vec3::new(padded_xz.max.x, y1, padded_xz.max.z),
-	);
-	cascade_chunk_from_aabb(water_bounds, res_2)
-}
-
 fn cascade_chunk_from_aabb(bounds: Aabb3d, res_2: u8) -> CascadeChunk {
 	let min = Vec3::from(bounds.min);
 	let max = Vec3::from(bounds.max);

--- a/maybraid/durham/models/src/water.rs
+++ b/maybraid/durham/models/src/water.rs
@@ -1,21 +1,29 @@
-//! Durham water model: collect stamp-owned fills against composed terrain and mesh them.
+//! Durham water model: compose stamp-owned lake fills and mesh them on the **terrain** lattice.
 //!
-//! Parallel to [`crate::terrain`]: terrain owns the heightfield; this module owns
-//! water fill products, evaluation, and presentation. Surface level / softmask
-//! boundary remain decisions of **Marazion** lake stamps.
+//! # Parallel to terrain
 //!
-//! **Order:** [`Terrain`] must compose **all** Marazion watershed bands (high-pass
-//! then low-pass) before fills are evaluated. [`Water`] therefore reads
-//! [`Terrain::marazion_fills`] from an already-built cell and samples wet volume
-//! only against that finished heightfield — never by regenerating lake leaves
-//! mid-compose.
+//! | Layer | Terrain | Water |
+//! | --- | --- | --- |
+//! | Origin tiling | [`TerrainCellLayout`] | same (`original_ids_for_origin_cells`) |
+//! | Composition | [`ComposedTerrain`] / [`Terrain::compose_sdf`] | [`ComposedWater`] / [`ComposedWater::compose`] |
+//! | Cascade chunk | [`cascade_chunk_for_cell`] | **same helper**, same `cell` + `res_2` |
+//! | Mesh resolution | [`TerrainPresentationAssets::res_2`](crate::terrain::presentation::TerrainPresentationAssets) via the sibling [`Terrain`] cell | inherited from that [`Terrain::res_2`] — never a separate water grid |
+//!
+//! Marazion lake stamps author [`WaterFill`] (surface \(W\), softmask, undercut gate).
+//! Fills are free-surface half-spaces below \(W\) so they resolve on the tall
+//! terrain Y lattice. This module collects those fills from an already composed
+//! [`Terrain`] cell and presents [`ComposedWater`] on that shared sample space.
+//!
+//! **Order:** [`Terrain`] must compose **all** Marazion watershed bands before
+//! fills are evaluated. [`Water`] reads [`Terrain::marazion_fills`] from that
+//! finished cell — never by regenerating leaves mid-compose.
 
 pub mod composed;
 pub mod plugin;
 pub mod presentation;
 
 use crate::terrain::cell::{original_ids_for_origin_cells, TerrainCellLayout};
-use crate::terrain::render::cascade_chunk_for_water_cell;
+use crate::terrain::render::cascade_chunk_for_cell;
 use crate::terrain::sdf::TerrainSdf;
 use crate::terrain::Terrain;
 use bevy::ecs::template::template;
@@ -35,17 +43,19 @@ pub use presentation::{
 	WaterPresenterState, WaterRegionPresenter, WaterStoreView,
 };
 
-/// Cell-level water collector over [`Terrain`] plus Marazion stamp fills.
+/// Cell-level water collector: same origin cell as [`Terrain`], composed fills + mesh.
 #[derive(Debug, Clone, Component)]
 pub struct Water {
+	/// Origin-cell AABB — identical to the sibling [`Terrain`] cell.
 	pub cell: Aabb3d,
 	/// Composed terrain heightfield used when evaluating fills.
 	pub terrain: TerrainSdf,
-	/// Stamp-owned lake fills (no re-derivation of W / shore).
+	/// Stamp-owned lake fills collected on this cell (wet-volume filtered).
 	pub fills: Vec<WaterFill>,
-	/// Meshable union of fills against [`Self::terrain`].
+	/// Meshable union of fills against [`Self::terrain`] ([`ComposedWater`]).
 	pub sdf: ComposedWater,
 	pub material: Handle<StandardMaterial>,
+	/// Cascade `res_2` copied from the sibling [`Terrain`] cell (shared lattice).
 	pub res_2: u8,
 }
 
@@ -60,13 +70,10 @@ impl Water {
 		self.sdf.distance(p)
 	}
 
-	/// Visual scene for one cell: cascade chunk + cached SDF mesh dispatch.
-	///
-	/// Uses the same XZ/`res_2` grid as terrain, with Y fitted to the water slab
-	/// so marching cubes can resolve basin depth (terrain cell Y is ~km-scale).
+	/// Visual scene for one cell: **same** cascade chunk as [`Terrain::scene`], then
+	/// cached [`ComposedWater`] mesh dispatch.
 	pub fn scene(&self) -> impl Scene + 'static {
-		let (y_min, y_max) = water_mesh_y_span(&self.fills, &self.terrain);
-		let chunk = cascade_chunk_for_water_cell(self.cell, self.res_2, y_min, y_max);
+		let chunk = cascade_chunk_for_cell(self.cell, self.res_2);
 		let transform = Transform::from_translation(chunk.origin);
 		let sdf = self.sdf.clone();
 		let material = self.material.clone();
@@ -100,29 +107,6 @@ fn fill_has_wet_volume(fill: &WaterFill, terrain: &TerrainSdf) -> bool {
 	fill.wet_y_span(h).is_some()
 }
 
-/// Vertical span for water meshing: cover `[h_eff, W]` per fill with pad.
-fn water_mesh_y_span(fills: &[WaterFill], terrain: &TerrainSdf) -> (f32, f32) {
-	let mut y_lo = f32::INFINITY;
-	let mut y_hi = f32::NEG_INFINITY;
-	for fill in fills {
-		let center = fill.region.center();
-		let h = terrain.height_at_with_all_modulations(center.x, center.y);
-		if let Some((lo, hi)) = fill.wet_y_span(h) {
-			y_lo = y_lo.min(lo);
-			y_hi = y_hi.max(hi);
-		} else {
-			y_lo = y_lo.min(h).min(fill.water_level);
-			y_hi = y_hi.max(h).max(fill.water_level);
-		}
-	}
-	if !y_lo.is_finite() || !y_hi.is_finite() {
-		return (-50.0, 50.0);
-	}
-	let depth = (y_hi - y_lo).abs().max(4.0);
-	let pad = (depth * 0.5).max(8.0);
-	(y_lo - pad, y_hi + pad)
-}
-
 impl<S> GenerationScheme<S> for Water
 where
 	S: GeneratingSpatialIndex<Terrain>
@@ -130,6 +114,7 @@ where
 		+ GeneratingSpatialIndex<WaterPresentationAssets>,
 {
 	fn original_ids_for(spatial_index: &mut S, region: Aabb3d) -> Vec<OriginalId> {
+		// Same origin-cell tiling controller as terrain.
 		original_ids_for_origin_cells(spatial_index, region)
 	}
 
@@ -141,6 +126,7 @@ where
 			id,
 			lod_ref,
 		)?;
+		// Lattice resolution comes from the terrain cell — not a water-only knob.
 		let res_2 = terrain.res_2;
 		let terrain_sdf = terrain.sdf.terrain.clone();
 		let fills: Vec<_> = terrain
@@ -157,7 +143,7 @@ where
 			Id::Universal,
 			lod_ref,
 		)?;
-		let sdf = ComposedWater::new(terrain_sdf.clone(), fills.clone());
+		let sdf = ComposedWater::compose(terrain_sdf.clone(), fills.clone());
 		Some((
 			Self {
 				cell: bounds,

--- a/maybraid/durham/models/src/water/composed.rs
+++ b/maybraid/durham/models/src/water/composed.rs
@@ -1,4 +1,19 @@
-//! Water volume SDF for meshing stamp-owned pocket fills.
+//! Water-fill composition layer — parallel to [`crate::terrain::sdf::ComposedTerrain`].
+//!
+//! [`Terrain`](crate::terrain::Terrain) composes elevation mods into a heightfield SDF
+//! and meshes it on the origin-cell cascade lattice
+//! ([`cascade_chunk_for_cell`](crate::terrain::render::cascade_chunk_for_cell)).
+//! This module is the matching **water** composition: stamp-owned [`WaterFill`]s
+//! unioned against that finished heightfield into one meshable [`ComposedWater`].
+//!
+//! **Same sample space as terrain.** Water cells are the same origin cells as
+//! [`TerrainCellLayout`](crate::terrain::cell::TerrainCellLayout), use the same
+//! `res_2`, and mesh with the same cascade chunk bounds (including full cell Y).
+//! Lake fills are free-surface half-spaces below \(W\) (see [`WaterFill`]) so the
+//! tall terrain Y lattice can resolve them the way it resolves terrain.
+//!
+//! Softmask bleed and empty-cell skips live at the stamp / [`Water`](crate::water::Water)
+//! collector layer; this type only evaluates the composed wet SDF.
 
 use crate::terrain::sdf::TerrainSdf;
 use crate::water::water_distance as fill_water_distance;
@@ -12,16 +27,30 @@ use sdf::{Sdf, Sign, SignBoundary, SignUniformIntervals};
 /// Softmask weight above which a column is treated as dry for Y-interval skips.
 const SOFTMASK_DRY: f32 = 0.999;
 
-/// Meshable water volume: union of stamp fills against a composed heightfield.
+/// Composed wet volume for one terrain origin cell: union of stamp fills against
+/// the cell's finished heightfield.
+///
+/// Analogous to [`ComposedTerrain`](crate::terrain::sdf::ComposedTerrain): stamps
+/// author fills; this type is the meshable product the water model presents on
+/// the shared cascade chunk.
 #[derive(Clone, Debug)]
 pub struct ComposedWater {
+	/// Finished heightfield (same instance the sibling [`Terrain`](crate::terrain::Terrain) cell composed).
 	pub terrain: TerrainSdf,
+	/// Stamp-owned fills whose support intersects this cell's collection pass.
 	pub fills: Vec<WaterFill>,
 }
 
 impl ComposedWater {
-	pub fn new(terrain: TerrainSdf, fills: Vec<WaterFill>) -> Self {
+	/// Compose stamp fills against a finished heightfield (water analogue of
+	/// [`Terrain::compose_sdf`](crate::terrain::Terrain::compose_sdf)).
+	pub fn compose(terrain: TerrainSdf, fills: Vec<WaterFill>) -> Self {
 		Self { terrain, fills }
+	}
+
+	/// Backward-compatible alias of [`Self::compose`].
+	pub fn new(terrain: TerrainSdf, fills: Vec<WaterFill>) -> Self {
+		Self::compose(terrain, fills)
 	}
 }
 
@@ -35,31 +64,34 @@ impl Sdf for ComposedWater {
 		let h = self.terrain.height_at_with_all_modulations(x, z);
 		let p_xz = Vec2::new(x, z);
 
-		let mut wet_bottom = f32::INFINITY;
+		// Lake fills are half-spaces below W: union of wet columns → (-∞, W_max].
 		let mut wet_top = f32::NEG_INFINITY;
+		let mut any_wet = false;
 		for fill in &self.fills {
 			let w = fill.softmask_at(p_xz.x, p_xz.y);
 			if w >= SOFTMASK_DRY {
 				continue;
 			}
-			if let Some((lo, hi)) = fill.wet_y_span(h) {
-				wet_bottom = wet_bottom.min(lo);
+			if let Some((_lo, hi)) = fill.wet_y_span(h) {
+				any_wet = true;
 				wet_top = wet_top.max(hi);
 			}
 		}
 
 		let mut intervals = SignUniformIntervals::default();
-		intervals.insert_boundary(SignBoundary {
-			min: f32::NEG_INFINITY,
-			sign: Sign::Positive,
-		});
-		if wet_bottom.is_finite() && wet_top > wet_bottom {
+		if any_wet && wet_top.is_finite() {
+			// Half-space below free surface — same shape as terrain's solid under h.
 			intervals.insert_boundary(SignBoundary {
-				min: wet_bottom,
+				min: f32::NEG_INFINITY,
 				sign: Sign::Negative,
 			});
 			intervals.insert_boundary(SignBoundary {
 				min: wet_top,
+				sign: Sign::Positive,
+			});
+		} else {
+			intervals.insert_boundary(SignBoundary {
+				min: f32::NEG_INFINITY,
 				sign: Sign::Positive,
 			});
 		}

--- a/maybraid/durham/models/src/water/presentation.rs
+++ b/maybraid/durham/models/src/water/presentation.rs
@@ -14,11 +14,14 @@ use lod::gen::{
 use lod::lod_ref::LodRef;
 use std::collections::{HashMap, HashSet};
 
-/// Material / mesh resolution used when building water instances.
+/// Material used when building water instances.
+///
+/// Mesh `res_2` and origin-cell bounds come from the sibling [`crate::terrain::Terrain`]
+/// cell / [`crate::terrain::cell::TerrainCellLayout`] — not from this resource — so
+/// water and terrain always share one cascade lattice.
 #[derive(Resource, Clone)]
 pub struct WaterPresentationAssets {
 	pub material: Handle<StandardMaterial>,
-	pub res_2: u8,
 }
 
 /// Bootstrap source used only when first materializing [`WaterPresentationAssets`]


### PR DESCRIPTION
Switch `Water` / `ComposedWater` to `cascade_chunk_for_cell` (same origin cells and `res_2` as terrain) and make lake `WaterFill` a free-surface half-space below \(W\) so tall cell Y can resolve water like terrain. Document the composition contract in durham-terrain-models CONTRIBUTING.