### PR TITLE
# Softens terrain shading

### DIFF
--- a/maybraid/durham/models-playground/src/lib.rs
+++ b/maybraid/durham/models-playground/src/lib.rs
@@ -125,7 +125,7 @@ fn setup_lighting(mut commands: Commands) {
 	));
 	commands.spawn((
 		DirectionalLight {
-			illuminance: 500.0,
+			illuminance: 2_500.0,
 			shadow_maps_enabled: false,
 			..default()
 		},

--- a/maybraid/durham/shaders/src/durham_terrain_shader.rs
+++ b/maybraid/durham/shaders/src/durham_terrain_shader.rs
@@ -27,7 +27,7 @@ impl Plugin for DurhamTerrainShaderPlugin {
 pub struct DurhamTerrainShader {
 	#[uniform(0)]
 	pub terrain_noise: DurhamTerrainNoiseUniform,
-	/// `x` = reserved, `y` = edge strength, `z` = edge darkness, `w` = lit mix.
+	/// `x` = normal soften (blend toward up), `y` = edge strength, `z` = edge darkness, `w` = lit mix.
 	#[uniform(1)]
 	pub style_params: Vec4,
 	/// RGB tint multiplied into the palette noise color; **w** = alpha.
@@ -39,7 +39,7 @@ impl Default for DurhamTerrainShader {
 	fn default() -> Self {
 		Self {
 			terrain_noise: DurhamTerrainNoiseUniform::default(),
-			style_params: Vec4::new(0.0, 2.0, 0.05, 0.72),
+			style_params: Vec4::new(0.35, 2.0, 0.05, 0.5),
 			base_color: Vec4::new(1.0, 1.0, 1.0, 1.0),
 		}
 	}
@@ -93,7 +93,8 @@ mod tests {
 		assert!((m.terrain_noise.bands[0].config.x - 120_079.0).abs() < 1e-3);
 		assert!((m.terrain_noise.regional_blend.x - 0.00015).abs() < 1e-8);
 		assert!((m.terrain_noise.regional_blend.y - 0.5).abs() < 1e-8);
-		assert!((m.style_params.w - 0.72).abs() < 1e-5);
+		assert!((m.style_params.x - 0.35).abs() < 1e-5);
+		assert!((m.style_params.w - 0.5).abs() < 1e-5);
 		assert!((m.base_color.x - 1.0).abs() < 1e-5);
 	}
 

--- a/maybraid/durham/shaders/src/durham_terrain_shader.wgsl
+++ b/maybraid/durham/shaders/src/durham_terrain_shader.wgsl
@@ -200,8 +200,17 @@ fn fragment(
         is_front,
     );
 
+    // Blend toward up so low-poly N·L faceting is less sharp; 0 = mesh, 1 = flat lit.
+    let soften = saturate(style_params.x);
+    let soft_n = normalize(mix(
+        pbr_input.world_normal,
+        vec3<f32>(0.0, 1.0, 0.0),
+        soften,
+    ));
+    pbr_input.world_normal = soft_n;
+
     pbr_input.is_orthographic = view.clip_from_view[3].w == 1.0;
-    pbr_input.N = normalize(pbr_input.world_normal);
+    pbr_input.N = soft_n;
     pbr_input.V = fns::calculate_view(mesh.world_position, pbr_input.is_orthographic);
 
     let lit_color = fns::apply_pbr_lighting(pbr_input);


### PR DESCRIPTION
Reduce harsh low-poly terrain shading by lowering lit-mix, raising playground fill, and blending lighting normals. 
