### PR TITLE
Compares lazy vs. warm primitive scene loading. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "950238d3049d81006a6fd6b898a34cfc01bb5462a7668795a54d640aed19fd0a"
 dependencies = [
  "bevy_internal",
+ "tracing",
 ]
 
 [[package]]
@@ -587,6 +588,7 @@ dependencies = [
  "downcast-rs 2.0.2",
  "log",
  "thiserror 2.0.16",
+ "tracing",
  "variadics_please",
  "wasm-bindgen",
  "web-sys",
@@ -835,6 +837,7 @@ dependencies = [
  "slotmap",
  "smallvec",
  "thiserror 2.0.16",
+ "tracing",
  "variadics_please",
 ]
 
@@ -1192,6 +1195,7 @@ dependencies = [
  "bevy_platform",
  "bevy_utils",
  "tracing",
+ "tracing-error",
  "tracing-log",
  "tracing-oslog",
  "tracing-subscriber",
@@ -1505,6 +1509,7 @@ dependencies = [
  "naga",
  "nonmax",
  "offset-allocator",
+ "profiling",
  "send_wrapper",
  "smallvec",
  "thiserror 2.0.16",
@@ -5277,6 +5282,20 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+ "tracing",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pxfm"
@@ -6326,6 +6345,16 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/maybraid/lod/docs/partition-host-warm-vs-lazy.md
+++ b/maybraid/lod/docs/partition-host-warm-vs-lazy.md
@@ -1,0 +1,78 @@
+# Partition hosts: warm H/M/L vs lazy LodRef fine-pass
+
+Playground / Wizard’s Tower experiment (release, M4 Pro). Numbers are
+`system_commands` apply times from the playground timing layer unless noted.
+
+## Setups
+
+| Setup | Partition `scene_with_lod` | Fine-pass |
+| --- | --- | --- |
+| **Warm** | `warm_content_host_hsl` (High+Medium+Low content roots) | Probe writes level; visibility flips |
+| **Static bake** | Default `scene_with_level(current)` only (no host) | None for partitions |
+| **Lazy** | `LodSceneHost` + `PartitionNode` + one current root | `add_fine_pass_for::<PartitionNode>` (eager fulfill + cull) |
+
+Tower Medium remains one scene-chunk (not per-floor) in these runs.
+
+## Appear cost (Medium / exterior stand-up)
+
+| Setup | Approx. apply | Hosts after stand-up |
+| --- | --- | --- |
+| Warm | ~8 ms (debug ~85 ms) | ~220 |
+| Static bake | ~2.8 ms | 1 (tower only) |
+| Lazy | ~3.4 ms first forest, then ~4.4 ms at tower Medium | ~220 |
+
+Lazy is lighter **per level root** than warm (one mesh tier, not three). That matches
+expectation.
+
+## The abrasive pattern (lazy)
+
+With lazy hosts, the same structural work shows up as **two separate expensive
+frames** rather than one warmer hitch:
+
+1. **First forest** — when the building first presents partitions under the
+   active tower band (here ~3.4 ms, `hosts≈220`).
+2. **Approach thrash** — many frames of `update` → `spawn_requests=N` →
+   `cull despawned=N` as partition bands flip (4–10 hosts per frame in the
+   captured approach). Individually small, but continuous spawn/despawn.
+3. **Tower Medium** — another ~4.4 ms apply when the Medium exterior root
+   materializes and stands up its own partition-host forest under that root.
+
+So the user-facing feel can be **worse than a single ~8 ms warm hitch**: you pay
+a smaller bill twice (and nibble in between) instead of once.
+
+Warm’s trade: higher one-shot appear (all three mesh tiers), cheaper band flips
+afterward (visibility only).
+
+Lazy’s trade: cheaper per root, but **re-pay insert cost** when a new parent
+level root embeds a new host forest, plus **ongoing fulfill/cull** while moving.
+
+Static bake is cheapest to appear but does **not** update partition mesh LOD
+with the camera — not a fair functional baseline.
+
+## Reading the lazy log (sketch)
+
+```
+apply≈3.4ms  sync hosts=220          # first partition forest
+… update changed=N / spawn_requests=N / cull despawned=N …  # approach
+chunk begin Medium …
+apply≈4.4ms  complete                # Medium exterior + nested hosts
+sync hosts=219
+```
+
+## Implications
+
+- Do not treat “lazy is faster on Medium apply” as a win without watching the
+  approach path and any **second** parent-band stand-up.
+- If the dominant event is “building band appears,” warm (or warm-adjacent-only)
+  may still feel smoother than lazy nested hosts under a one-shot parent spawn.
+- If the dominant event is long-lived hosts with rare band changes, lazy (and
+  later chunked fulfill) is the better fit.
+- Nested hosts under a chunked/lazy **tower** still multiply cost: Medium is one
+  tower chunk that eagerly embeds N partition hosts.
+
+## Related
+
+- [`scene-chunks.md`](scene-chunks.md) — tower-level incremental fulfill
+- `PartitionNode::scene_with_lod` — lazy host wiring
+- Playground: `add_fine_pass_for::<PartitionNode>()` (eager), tower still on
+  `add_fine_pass_chunk_full_for::<WizardsTower>()`

--- a/maybraid/lod/docs/scene-chunks.md
+++ b/maybraid/lod/docs/scene-chunks.md
@@ -51,4 +51,5 @@ Lazy materialization of subtrees (factories evaluated only when the scheduler re
 
 - [`SceneChunk`](../lib/src/scene_chunk.rs)
 - [`chunk_fulfill`](../lib/src/chunk_fulfill.rs)
+- [Partition host warm vs lazy](partition-host-warm-vs-lazy.md)
 - [Richmond CONTRIBUTING — LodScene](../../richmond/CONTRIBUTING.md#lodscene-on-buildings)

--- a/maybraid/lod/lib/src/chunk_fulfill.rs
+++ b/maybraid/lod/lib/src/chunk_fulfill.rs
@@ -5,10 +5,13 @@
 //! [`LodChunkFulfillBudget`], then atomically swaps visibility.
 //!
 //! Pipeline (within [`crate::LodFinePassSystems::Fulfill`]):
-//! cancel stale → begin jobs from [`LodLevelSpawnRequest`] → drain budget →
-//! complete / swap.
+//! cancel stale → begin jobs → drain budget → complete / swap.
+//!
+//! Command / archetype apply cost is measured via Bevy's `system_commands`
+//! tracing spans (requires the `trace` feature) at auto-[`ApplyDeferred`] points.
 
 use std::collections::VecDeque;
+use std::time::Instant;
 
 use bevy::prelude::*;
 use bevy::scene::prelude::{bsn, template_value};
@@ -39,8 +42,19 @@ pub struct LodChunkFulfillBudget {
 
 impl Default for LodChunkFulfillBudget {
 	fn default() -> Self {
-		Self { weights_per_frame: 32 }
+		Self { weights_per_frame: 4 }
 	}
+}
+
+/// Diagnostic: last `scene_chunks_with_level` timing (scene build, not apply).
+#[derive(Resource, Debug, Default)]
+pub struct LodChunkFulfillDiag {
+	pub last_scene_chunks_ms: f64,
+	pub last_level: Option<LodSceneLevel>,
+}
+
+fn ms(start: Instant) -> f64 {
+	start.elapsed().as_secs_f64() * 1000.0
 }
 
 /// Cancel pending roots whose level is no longer desired.
@@ -50,6 +64,8 @@ pub fn cancel_stale_chunk_fulfillments(
 	level_roots_heads: Query<&Children, With<LodLevelRoots>>,
 	pending_roots: Query<&LodLevelRoot, With<LodLevelRootPending>>,
 ) {
+	let t0 = Instant::now();
+	let mut despawned = 0u32;
 	for (host, desired, host_children) in &hosts {
 		let Some(host_children) = host_children else {
 			continue;
@@ -73,9 +89,16 @@ pub fn cancel_stale_chunk_fulfillments(
 			};
 			if root.0 != *desired {
 				commands.entity(child).despawn();
+				despawned += 1;
 			}
 		}
 		let _ = host;
+	}
+	if despawned > 0 {
+		info!(
+			"[lod.chunk] cancel_stale: {despawned} despawned in {:.2}ms",
+			ms(t0)
+		);
 	}
 }
 
@@ -83,6 +106,7 @@ pub fn cancel_stale_chunk_fulfillments(
 pub fn begin_chunk_lod_fulfill<T: Component + LodScene>(
 	mut commands: Commands,
 	viewer: Res<LodViewerState>,
+	mut diag: ResMut<LodChunkFulfillDiag>,
 	hosts: Query<
 		(Entity, &T, Option<&LodHostBounds>, &LodLevelSpawnRequest, &Children),
 		With<LodSceneHost>,
@@ -94,6 +118,11 @@ pub fn begin_chunk_lod_fulfill<T: Component + LodScene>(
 	if viewer.entity == Entity::PLACEHOLDER {
 		return;
 	}
+
+	let t_sys = Instant::now();
+	let mut jobs_started = 0u32;
+	let mut chunks_ms_total = 0.0f64;
+	let mut spawn_ms_total = 0.0f64;
 
 	for (host, scene, host_bounds, request, host_children) in &hosts {
 		let bounds = ephemeral_bounds(host_bounds);
@@ -133,8 +162,17 @@ pub fn begin_chunk_lod_fulfill<T: Component + LodScene>(
 			}
 		}
 
+		let t_chunks = Instant::now();
 		let chunk = scene.scene_chunks_with_level(&lod_ref, request.level);
 		let queue = chunk.into_primitives();
+		let chunks_ms = ms(t_chunks);
+		chunks_ms_total += chunks_ms;
+		let queue_len = queue.len();
+		let queue_weight: u32 = queue.iter().map(|(w, _)| *w).sum();
+		diag.last_scene_chunks_ms = chunks_ms;
+		diag.last_level = Some(request.level);
+
+		let t_spawn = Instant::now();
 		let level = request.level;
 		let level_root = bsn! {
 			template_value(LodLevelRoot(level))
@@ -146,6 +184,24 @@ pub fn begin_chunk_lod_fulfill<T: Component + LodScene>(
 		commands.entity(root_entity).insert(LodChunkFulfillment { queue });
 		commands.entity(roots_entity).add_child(root_entity);
 		commands.entity(host).remove::<LodLevelSpawnRequest>();
+		let spawn_ms = ms(t_spawn);
+		spawn_ms_total += spawn_ms;
+		jobs_started += 1;
+
+		info!(
+			"[lod.chunk] begin job host={host:?} level={level:?}: \
+			 scene_chunks_with_level={chunks_ms:.2}ms queue_len={queue_len} \
+			 queue_weight={queue_weight} queue_root_cmds={spawn_ms:.2}ms"
+		);
+	}
+
+	if jobs_started > 0 {
+		info!(
+			"[lod.chunk] begin_chunk_lod_fulfill: {jobs_started} jobs, \
+			 scene_chunks_with_level={chunks_ms_total:.2}ms queue_root_cmds={spawn_ms_total:.2}ms \
+			 total={:.2}ms",
+			ms(t_sys)
+		);
 	}
 }
 
@@ -158,11 +214,17 @@ pub fn drain_chunk_lod_fulfill(
 	budget: Res<LodChunkFulfillBudget>,
 	mut jobs: Query<(Entity, &mut LodChunkFulfillment), With<LodLevelRootPending>>,
 ) {
+	let t0 = Instant::now();
 	let mut remaining = budget.weights_per_frame;
+	let mut spawned = 0u32;
+	let mut weight_spent = 0u32;
+	let mut active_jobs = 0u32;
+
 	for (root, mut job) in &mut jobs {
 		if job.queue.is_empty() {
 			continue;
 		}
+		active_jobs += 1;
 		let mut spawned_this_job = false;
 		while !job.queue.is_empty() {
 			if remaining == 0 && spawned_this_job {
@@ -179,9 +241,22 @@ pub fn drain_chunk_lod_fulfill(
 			};
 			let child = commands.spawn_scene(piece).id();
 			commands.entity(root).add_child(child);
-			remaining = remaining.saturating_sub(weight.max(1));
+			let w = weight.max(1);
+			remaining = remaining.saturating_sub(w);
+			weight_spent += w;
+			spawned += 1;
 			spawned_this_job = true;
 		}
+	}
+
+	if spawned > 0 {
+		info!(
+			"[lod.chunk] drain: queued_spawns={spawned} weight_spent={weight_spent} \
+			 budget={} active_jobs={active_jobs} queue_cmds={:.2}ms \
+			 (apply cost: watch [lod.commands] system_commands)",
+			budget.weights_per_frame,
+			ms(t0)
+		);
 	}
 }
 
@@ -195,6 +270,8 @@ pub fn complete_chunk_lod_fulfill(
 	level_roots_heads: Query<&Children, With<LodLevelRoots>>,
 	mut visibilities: Query<&mut Visibility>,
 ) {
+	let t0 = Instant::now();
+	let mut completed = 0u32;
 	for (root_entity, fulfillment, child_of) in &pending {
 		if fulfillment.is_some_and(|f| !f.queue.is_empty()) {
 			continue;
@@ -203,6 +280,7 @@ pub fn complete_chunk_lod_fulfill(
 		if let Ok(mut vis) = visibilities.get_mut(root_entity) {
 			*vis = Visibility::Inherited;
 		}
+		completed += 1;
 
 		let Some(child_of) = child_of else {
 			continue;
@@ -220,6 +298,12 @@ pub fn complete_chunk_lod_fulfill(
 			}
 		}
 	}
+	if completed > 0 {
+		info!(
+			"[lod.chunk] complete: {completed} roots swapped in {:.2}ms",
+			ms(t0)
+		);
+	}
 }
 
 /// Register incremental fulfill systems for one [`LodScene`] host type.
@@ -228,16 +312,20 @@ pub fn complete_chunk_lod_fulfill(
 /// (or in place of) the fulfill half of [`crate::add_fine_pass_for`].
 pub fn add_fine_pass_chunk_for<T: Component + LodScene>(app: &mut App) {
 	crate::fine_pass::configure_fine_pass_sets(app);
-	app.init_resource::<LodChunkFulfillBudget>().add_systems(
-		Update,
-		(
-			cancel_stale_chunk_fulfillments.in_set(LodFinePassSystems::Fulfill),
-			begin_chunk_lod_fulfill::<T>.in_set(LodFinePassSystems::Fulfill),
-			drain_chunk_lod_fulfill.in_set(LodFinePassSystems::Fulfill),
-			complete_chunk_lod_fulfill.in_set(LodFinePassSystems::Fulfill),
-		)
-			.chain(),
-	);
+	app.init_resource::<LodChunkFulfillBudget>()
+		.init_resource::<LodChunkFulfillDiag>()
+		.add_systems(
+			Update,
+			(
+				cancel_stale_chunk_fulfillments.in_set(LodFinePassSystems::Fulfill),
+				begin_chunk_lod_fulfill::<T>.in_set(LodFinePassSystems::Fulfill),
+				drain_chunk_lod_fulfill.in_set(LodFinePassSystems::Fulfill),
+				complete_chunk_lod_fulfill.in_set(LodFinePassSystems::Fulfill),
+			)
+				// Auto-ApplyDeferred between steps applies Commands (measured via
+				// `system_commands` spans when the `trace` feature is enabled).
+				.chain(),
+		);
 }
 
 /// Like [`crate::add_fine_pass_for`], but uses chunk fulfill instead of eager spawn.

--- a/maybraid/lod/lib/src/fine_pass.rs
+++ b/maybraid/lod/lib/src/fine_pass.rs
@@ -120,12 +120,23 @@ pub fn update_lod_host_levels<T: Component + LodScene>(
 	if viewer.entity == Entity::PLACEHOLDER {
 		return;
 	}
+	let t0 = std::time::Instant::now();
+	let mut changed = 0u32;
+	let mut n = 0u32;
 	for (scene, bounds, mut level) in &mut hosts {
+		n += 1;
 		let lod_ref = viewer.lod_ref(&bounds.0);
 		let desired = scene.scene_lod_level(&lod_ref);
 		if *level != desired {
 			*level = desired;
+			changed += 1;
 		}
+	}
+	let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+	if changed > 0 || elapsed_ms >= 0.5 {
+		info!(
+			"[lod.fine] update_lod_host_levels: hosts={n} changed={changed} in {elapsed_ms:.2}ms"
+		);
 	}
 }
 
@@ -221,6 +232,9 @@ pub fn cull_lod_level_roots<T: Component + LodScene>(
 		return;
 	}
 
+	let t0 = std::time::Instant::now();
+	let mut despawned = 0u32;
+
 	for (scene, host_bounds, current, host_children) in &hosts {
 		let bounds = ephemeral_bounds(host_bounds);
 		let lod_ref = viewer.lod_ref(&bounds);
@@ -253,8 +267,15 @@ pub fn cull_lod_level_roots<T: Component + LodScene>(
 			}
 			if culls.should_cull(root.0) {
 				commands.entity(child).despawn();
+				despawned += 1;
 			}
 		}
+	}
+	let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+	if despawned > 0 || elapsed_ms >= 0.5 {
+		info!(
+			"[lod.fine] cull_lod_level_roots: despawned={despawned} in {elapsed_ms:.2}ms"
+		);
 	}
 }
 

--- a/maybraid/lod/lib/src/lod_scene_host.rs
+++ b/maybraid/lod/lib/src/lod_scene_host.rs
@@ -76,12 +76,17 @@ pub fn sync_lod_level_roots(
 	pending: Query<(), With<crate::LodLevelRootPending>>,
 	mut visibilities: Query<&mut Visibility>,
 ) {
+	let t0 = std::time::Instant::now();
+	let mut n = 0u32;
+	let mut requested = 0u32;
 	for (host, level, host_children) in &hosts {
+		n += 1;
 		let desired = *level;
 
 		// No children yet → nothing to show/hide; ask for the first level root to be spawned.
 		let Some(host_children) = host_children else {
 			commands.entity(host).insert(LodLevelSpawnRequest { level: desired });
+			requested += 1;
 			continue;
 		};
 
@@ -97,6 +102,7 @@ pub fn sync_lod_level_roots(
 		// Host has children but no LodLevelRoots yet → same as cold start: request a spawn.
 		let Some(roots_entity) = roots_entity else {
 			commands.entity(host).insert(LodLevelSpawnRequest { level: desired });
+			requested += 1;
 			continue;
 		};
 
@@ -132,7 +138,14 @@ pub fn sync_lod_level_roots(
 			commands.entity(host).remove::<LodLevelSpawnRequest>();
 		} else {
 			commands.entity(host).insert(LodLevelSpawnRequest { level: desired });
+			requested += 1;
 		}
+	}
+	if n > 0 {
+		info!(
+			"[lod.fine] sync_lod_level_roots: hosts={n} spawn_requests={requested} in {:.2}ms",
+			t0.elapsed().as_secs_f64() * 1000.0
+		);
 	}
 }
 

--- a/maybraid/richmond/building-components/src/parent_confines.rs
+++ b/maybraid/richmond/building-components/src/parent_confines.rs
@@ -100,12 +100,21 @@ pub fn apply_parent_confines(
 	let Ok(viewer_tf) = viewer.single() else {
 		return;
 	};
+	let t0 = std::time::Instant::now();
+	let mut n = 0u32;
 	for (confines, mut visibility) in &mut hosts {
+		n += 1;
 		*visibility = if confines.viewer_allowed(viewer_tf) {
 			Visibility::Inherited
 		} else {
 			Visibility::Hidden
 		};
+	}
+	let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+	if elapsed_ms >= 0.5 {
+		bevy::log::info!(
+			"[lod.confines] apply_parent_confines: hosts={n} in {elapsed_ms:.2}ms"
+		);
 	}
 }
 

--- a/maybraid/richmond/building-components/src/partitions/geometry.rs
+++ b/maybraid/richmond/building-components/src/partitions/geometry.rs
@@ -54,6 +54,12 @@ pub enum PartitionGeometry {
 	SliceArc(ArcSweep),
 }
 
+impl Default for PartitionGeometry {
+	fn default() -> Self {
+		Self::Linear(LinearPartition::default())
+	}
+}
+
 /// Alias for continuous partition geometry.
 pub type Partition = PartitionGeometry;
 

--- a/maybraid/richmond/building-components/src/partitions/node.rs
+++ b/maybraid/richmond/building-components/src/partitions/node.rs
@@ -3,18 +3,26 @@
 //! Covers both **direct** component mappings (e.g. a single linear / arc kit) and
 //! **tessellated** concepts (polyline / continuous arc → many tiles under **one** LOD
 //! parent host). Leaf style types still expose per-mesh hosts for playground previews.
+//!
+//! [`PartitionNode::scene_with_lod`] builds a **lazy** [`lod::LodSceneHost`]: one level
+//! root at spawn; fine-pass update / eager fulfill / cull bring other bands as the
+//! viewer moves (see playground `add_fine_pass_for::<PartitionNode>`).
 
-use bevy::scene::prelude::Scene;
+use bevy::math::bounding::Aabb3d;
+use bevy::prelude::{Children, Component, Transform, Visibility};
+use bevy::scene::prelude::{bsn, template_value, Scene};
 use bevy_math::Vec3;
+use lod::fine_pass::LodHostBounds;
 use lod::gen::{LodScene, LodSceneCulls, LodSceneLevel, LodSceneStatus};
 use lod::lod_ref::LodRef;
+use lod::lod_scene_host::{LodLevelRoot, LodLevelRoots, LodSceneHost};
 
-use crate::floors::RoughStoneFloorRightTriangle;
-use crate::lod_band::warm_mesh_lod_culls;
-use crate::lod_host::warm_content_host_hsl;
+use crate::assets::panels::rough_stonework::{
+	RIGHT_TRIANGLE_HIGH, RIGHT_TRIANGLE_LOW, RIGHT_TRIANGLE_MID,
+};
+use crate::lod_band::{characteristic_extent_abs, placement_center, warm_mesh_lod_culls};
 use crate::parent_confines::{confined_scene, ParentConfines};
 use crate::partitions::geometry::{JointLod, LinearLod, PartitionGeometry, PartitionTile};
-use crate::partitions::probe::PartitionLodProbe;
 use crate::partitions::rough_stonework::{
 	RoughStoneworkJoint, RoughStoneworkLinearSliceSubsegment, RoughStoneworkLinearSubsegment,
 	RoughStoneworkSlice180,
@@ -24,7 +32,7 @@ use crate::placed::Placement;
 use crate::scene_children::{pose, scene_children, with_pose};
 
 /// Authoring IR for a partition feature (primitive — no portals).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Component, Default)]
 pub struct PartitionNode {
 	pub style: PartitionStyle,
 	pub geometry: PartitionGeometry,
@@ -60,7 +68,15 @@ impl PartitionNode {
 		node.scene_lod_status(lod_ref)
 	}
 
+	/// AABB for [`LodHostBounds`] from placement center / characteristic extent.
+	pub fn host_bounds(&self) -> Aabb3d {
+		let center = placement_center(&self.placement);
+		let half = Vec3::splat(characteristic_extent_abs(&self.placement) * 0.5);
+		Aabb3d::from_min_max(center - half, center + half)
+	}
+
 	fn kit_scenes_for_level(&self, lod_ref: &LodRef, level: LodSceneLevel) -> Vec<Box<dyn Scene>> {
+		let _ = lod_ref;
 		self.geometry
 			.placed_tiles_for_style(self.style, self.placement)
 			.into_iter()
@@ -74,25 +90,72 @@ impl PartitionNode {
 							}
 							Some(Box::new(JointLod::posed_tier(transform, level)) as Box<dyn Scene>)
 						}
-						PartitionTile::RightTriangle { mirror } => Some(Box::new(with_pose(
-							transform,
-							RoughStoneFloorRightTriangle::scene_with_lod_mirrored(lod_ref, mirror),
-						)) as Box<dyn Scene>),
+						PartitionTile::RightTriangle { mirror } => {
+							Some(Box::new(posed_right_triangle_tier(transform, level, mirror))
+								as Box<dyn Scene>)
+						}
 						tile => {
 							if let Some(meshes) = tile.mesh_set() {
 								Some(Box::new(LinearLod::posed_tier(meshes, transform, level))
 									as Box<dyn Scene>)
 							} else {
-								Some(Box::new(with_pose(
-									transform,
-									placeholder_tile_scene(tile, lod_ref),
-								)) as Box<dyn Scene>)
+								None
 							}
 						}
 					},
 				}
 			})
 			.collect()
+	}
+}
+
+fn posed_right_triangle_tier(
+	transform: Transform,
+	level: LodSceneLevel,
+	mirror: Option<scene_ref::MirrorAxis>,
+) -> impl Scene + 'static {
+	let path = match level {
+		LodSceneLevel::High => RIGHT_TRIANGLE_HIGH,
+		LodSceneLevel::Medium => RIGHT_TRIANGLE_MID,
+		LodSceneLevel::Low
+		| LodSceneLevel::UltraLow
+		| LodSceneLevel::Distance(_)
+		| LodSceneLevel::Resolution(_) => RIGHT_TRIANGLE_LOW,
+	};
+	with_pose(transform, path.scene_ref().with_mirror(mirror).scene())
+}
+
+/// Lazy host: [`LodSceneHost`] + [`PartitionNode`] + one active level root.
+fn lazy_partition_host(
+	node: PartitionNode,
+	level: LodSceneLevel,
+	bounds: Aabb3d,
+	content: impl Scene + 'static,
+) -> impl Scene + 'static {
+	let content_children: Vec<Box<dyn Scene>> = vec![Box::new(content)];
+	let level_root: Box<dyn Scene> = Box::new(bsn! {
+		template_value(LodLevelRoot(level))
+		Transform::default()
+		Visibility::Inherited
+		Children [ {content_children} ]
+	});
+	let level_roots_children: Vec<Box<dyn Scene>> = vec![level_root];
+	let roots: Box<dyn Scene> = Box::new(bsn! {
+		LodLevelRoots
+		Transform::default()
+		Visibility::Inherited
+		Children [ {level_roots_children} ]
+	});
+	let host_children: Vec<Box<dyn Scene>> = vec![roots];
+	let host_bounds = LodHostBounds(bounds);
+	bsn! {
+		LodSceneHost
+		template_value(node)
+		template_value(level)
+		template_value(host_bounds)
+		Transform::default()
+		Visibility::Inherited
+		Children [ {host_children} ]
 	}
 }
 
@@ -106,7 +169,7 @@ fn placeholder_tile_scene(tile: PartitionTile, lod_ref: &LodRef) -> Box<dyn Scen
 		}
 		PartitionTile::SliceArc180 => Box::new(RoughStoneworkSlice180.scene_with_lod(lod_ref)),
 		PartitionTile::Joint => Box::new(RoughStoneworkJoint.scene_with_lod(lod_ref)),
-		_ => Box::new(RoughStoneworkLinearSubsegment.scene_with_lod(lod_ref)),
+		_ => Box::new(RoughStoneworkLinearSubsegment.scene_with_lod(lod_ref))
 	}
 }
 
@@ -148,13 +211,11 @@ impl LodScene for PartitionNode {
 
 	fn scene_with_lod(&self, lod_ref: &LodRef) -> impl Scene + 'static {
 		let level = self.scene_lod_level(lod_ref);
-		let probe = PartitionLodProbe::from_placement(&self.placement);
-		warm_content_host_hsl(
+		lazy_partition_host(
+			self.clone(),
 			level,
-			probe,
-			self.scene_with_level(lod_ref, LodSceneLevel::High),
-			self.scene_with_level(lod_ref, LodSceneLevel::Medium),
-			self.scene_with_level(lod_ref, LodSceneLevel::Low),
+			self.host_bounds(),
+			self.scene_with_level(lod_ref, level),
 		)
 	}
 }

--- a/maybraid/richmond/building-components/src/partitions/probe.rs
+++ b/maybraid/richmond/building-components/src/partitions/probe.rs
@@ -149,11 +149,22 @@ pub fn update_partition_host_levels(
 	if viewer.entity == bevy::prelude::Entity::PLACEHOLDER {
 		return;
 	}
+	let t0 = std::time::Instant::now();
+	let mut n = 0u32;
+	let mut changed = 0u32;
 	for (probe, mut level) in &mut hosts {
+		n += 1;
 		let desired = probe.level_for(&viewer.current);
 		if *level != desired {
 			*level = desired;
+			changed += 1;
 		}
+	}
+	let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+	if changed > 0 || elapsed_ms >= 0.5 {
+		bevy::log::info!(
+			"[lod.partition] update_partition_host_levels: hosts={n} changed={changed} in {elapsed_ms:.2}ms"
+		);
 	}
 }
 

--- a/maybraid/richmond/buildings-playground/Cargo.toml
+++ b/maybraid/richmond/buildings-playground/Cargo.toml
@@ -14,7 +14,8 @@ name = "richmond-buildings-playground"
 path = "src/main.rs"
 
 [dependencies]
-bevy = { workspace = true }
+# `trace` enables bevy_ecs `system_commands` spans used to time command apply.
+bevy = { workspace = true, features = ["trace"] }
 bevy_math = { workspace = true }
 clap = { workspace = true }
 game-commands = { workspace = true }

--- a/maybraid/richmond/buildings-playground/src/lib.rs
+++ b/maybraid/richmond/buildings-playground/src/lib.rs
@@ -18,7 +18,8 @@ use game_commands::command::{capture_command_line_input, GameCommandPlugin};
 use game_commands::ui::GameCommandStatusText;
 use ground::setup_ground;
 use lod::{
-	add_fine_pass_chunk_full_for, add_fine_pass_cull_for, LodFinePassPlugin, LodFinePassSystems,
+	add_fine_pass_chunk_full_for, add_fine_pass_cull_for, LodChunkFulfillBudget, LodFinePassPlugin,
+	LodFinePassSystems,
 };
 use preview::{
 	draw_connecting_hall_gizmos, draw_connecting_shells_gizmos, draw_label_text_gizmos,
@@ -37,6 +38,9 @@ impl Plugin for RichmondBuildingsPlaygroundPlugin {
 	fn build(&self, app: &mut App) {
 		app.init_resource::<PreviewConfig>()
 			.init_resource::<CachedPreview>()
+			.insert_resource(LodChunkFulfillBudget {
+				weights_per_frame: 1,
+			})
 			.add_plugins((
 				SceneRefPlugin,
 				FurnitureWireframePlugin,

--- a/maybraid/richmond/buildings-playground/src/lib.rs
+++ b/maybraid/richmond/buildings-playground/src/lib.rs
@@ -18,8 +18,8 @@ use game_commands::command::{capture_command_line_input, GameCommandPlugin};
 use game_commands::ui::GameCommandStatusText;
 use ground::setup_ground;
 use lod::{
-	add_fine_pass_chunk_full_for, add_fine_pass_cull_for, LodChunkFulfillBudget, LodFinePassPlugin,
-	LodFinePassSystems,
+	add_fine_pass_chunk_full_for, add_fine_pass_cull_for, add_fine_pass_for, LodChunkFulfillBudget,
+	LodFinePassPlugin, LodFinePassSystems,
 };
 use preview::{
 	draw_connecting_hall_gizmos, draw_connecting_shells_gizmos, draw_label_text_gizmos,
@@ -27,7 +27,7 @@ use preview::{
 };
 use richmond_building_components::{
 	apply_parent_confines, update_partition_host_levels, update_roof_host_levels,
-	FurnitureWireframePlugin, LabelWireframePlugin, WarmAssetLodRoots,
+	FurnitureWireframePlugin, LabelWireframePlugin, PartitionNode, WarmAssetLodRoots,
 };
 use richmond_buildings::wizards_tower::{TowerSilhouettePlugin, WizardsTower};
 use scene_ref::SceneRefPlugin;
@@ -51,7 +51,9 @@ impl Plugin for RichmondBuildingsPlaygroundPlugin {
 			));
 		// Wizard's Tower: incremental chunk fulfill (experiment).
 		add_fine_pass_chunk_full_for::<WizardsTower>(app);
-		// Probe updates LodSceneLevel; WarmAssetLodRoots handles spawn + cull.
+		// Partition IR hosts: lazy level roots, eager fulfill (vs warm H/M/L).
+		add_fine_pass_for::<PartitionNode>(app);
+		// Leaf GLB kits: probe updates LodSceneLevel; WarmAssetLodRoots spawn + cull.
 		add_fine_pass_cull_for::<WarmAssetLodRoots>(app);
 		app.add_systems(Startup, (camera::setup_camera, setup_lighting, setup_ground))
 			.add_systems(

--- a/maybraid/richmond/buildings-playground/src/main.rs
+++ b/maybraid/richmond/buildings-playground/src/main.rs
@@ -1,5 +1,13 @@
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
+use bevy::log::tracing::field::{Field, Visit};
+use bevy::log::tracing::span::{Attributes, Id};
+use bevy::log::tracing::Subscriber;
+use bevy::log::tracing_subscriber::layer::Context;
+use bevy::log::tracing_subscriber::registry::LookupSpan;
+use bevy::log::tracing_subscriber::Layer;
+use bevy::log::{BoxedLayer, LogPlugin};
 use bevy::prelude::*;
 use richmond_buildings_playground::{
 	PendingStartupCommand, PlaygroundCommand, RichmondBuildingsPlaygroundPlugin,
@@ -7,6 +15,98 @@ use richmond_buildings_playground::{
 
 fn assets_root() -> PathBuf {
 	Path::new(env!("CARGO_MANIFEST_DIR")).join("../../assets")
+}
+
+/// Wall time from last enter of a `system_commands` span.
+struct CommandApplyTimer(Instant);
+
+struct SystemName(String);
+
+/// Logs Bevy's built-in `system_commands` spans (command / archetype apply) when
+/// they exceed a small threshold — no Tracy, no fulfill-path changes.
+struct SystemCommandsTimingLayer {
+	threshold_ms: f64,
+}
+
+impl SystemCommandsTimingLayer {
+	fn new(threshold_ms: f64) -> Self {
+		Self { threshold_ms }
+	}
+}
+
+impl<S> Layer<S> for SystemCommandsTimingLayer
+where
+	S: Subscriber + for<'a> LookupSpan<'a>,
+{
+	fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+		if attrs.metadata().name() != "system_commands" {
+			return;
+		}
+		let Some(span) = ctx.span(id) else {
+			return;
+		};
+		let mut name = SystemNameVisitor::default();
+		attrs.record(&mut name);
+		let mut ext = span.extensions_mut();
+		if let Some(n) = name.0 {
+			ext.insert(SystemName(n));
+		}
+		ext.insert(CommandApplyTimer(Instant::now()));
+	}
+
+	fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+		let Some(span) = ctx.span(id) else {
+			return;
+		};
+		if span.metadata().name() != "system_commands" {
+			return;
+		}
+		span.extensions_mut().replace(CommandApplyTimer(Instant::now()));
+	}
+
+	fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+		let Some(span) = ctx.span(id) else {
+			return;
+		};
+		if span.metadata().name() != "system_commands" {
+			return;
+		}
+		let ext = span.extensions();
+		let Some(CommandApplyTimer(start)) = ext.get::<CommandApplyTimer>() else {
+			return;
+		};
+		let ms = start.elapsed().as_secs_f64() * 1000.0;
+		if ms < self.threshold_ms {
+			return;
+		}
+		let name = ext
+			.get::<SystemName>()
+			.map(|n| n.0.as_str())
+			.unwrap_or("<unknown>");
+		// eprintln avoids re-entrancy through the logging subscriber.
+		eprintln!("[lod.commands] system_commands apply={ms:.2}ms system={name}");
+	}
+}
+
+#[derive(Default)]
+struct SystemNameVisitor(Option<String>);
+
+impl Visit for SystemNameVisitor {
+	fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+		if field.name() == "name" {
+			self.0 = Some(format!("{value:?}"));
+		}
+	}
+
+	fn record_str(&mut self, field: &Field, value: &str) {
+		if field.name() == "name" {
+			self.0 = Some(value.to_owned());
+		}
+	}
+}
+
+fn command_apply_timing_layer(_app: &mut App) -> Option<BoxedLayer> {
+	Some(Box::new(SystemCommandsTimingLayer::new(0.25)))
 }
 
 fn main() {
@@ -32,7 +132,11 @@ fn main() {
 					}),
 					..default()
 				})
-				.set(AssetPlugin { file_path: assets_path.to_string_lossy().into(), ..default() }),
+				.set(AssetPlugin { file_path: assets_path.to_string_lossy().into(), ..default() })
+				.set(LogPlugin {
+					custom_layer: command_apply_timing_layer,
+					..default()
+				}),
 		)
 		.insert_resource(ClearColor(Color::srgb(0.75, 0.82, 0.88)))
 		.insert_resource(PendingStartupCommand(startup))


### PR DESCRIPTION
# Summary
Partition primitive scenes implement warm loading. This increases the upfront incremental costs. Review indicate that lazy reduces archetypal cost, but that said cost is still paid over more frames which can create an arguably more abrasive experience. 